### PR TITLE
fix:超取冷凍免運費功能與共用API Key值不同問題

### DIFF
--- a/includes/woomp-paynow-shipping/src/settings/settings-woomp-paynow-shipping-c2c-711-frozen.php
+++ b/includes/woomp-paynow-shipping/src/settings/settings-woomp-paynow-shipping-c2c-711-frozen.php
@@ -34,24 +34,46 @@ $settings = [
 		'min'     => 0,
 		'step'    => 1,
 	],
-	'free_shipping_requires'   => [
-		'title'   => __( 'Free shipping requires', 'woomp' ),
+	'requires' => [
+		'title'   => __( 'Free shipping requires', 'woocommerce' ),
 		'type'    => 'select',
 		'class'   => 'wc-enhanced-select',
 		'default' => '',
 		'options' => [
-			''           => __( 'N/A', 'woomp' ),
-			'min_amount' => __( 'A minimum order amount', 'woomp' ),
+			''           => __( 'No requirement', 'woocommerce' ),
+			'coupon'     => __( 'A valid free shipping coupon', 'woocommerce' ),
+			'min_amount' => __( 'A minimum order amount', 'woocommerce' ),
+			'either'     => __( 'A minimum order amount OR coupon', 'woocommerce' ),
+			'both'       => __( 'A minimum order amount AND coupon', 'woocommerce' ),
 		],
 	],
-	'free_shipping_min_amount' => [
-		'title'       => __( 'Minimum order amount for free shipping', 'woomp' ),
+	'min_amount' => [
+		'title'       => __( 'Minimum order amount', 'ry-woocommerce-tools' ),
 		'type'        => 'price',
 		'default'     => 0,
 		'placeholder' => wc_format_localized_price( 0 ),
-		'description' => __( 'Users will need to spend this amount to get free shipping.', 'woomp' ),
+		'description' => __( 'Users will need to spend this amount to get free shipping (if enabled above).', 'woocommerce' ),
 		'desc_tip'    => true,
 	],
+	// 共用API使用的是'requires'
+	// 'free_shipping_requires'   => [
+	// 	'title'   => __( 'Free shipping requires', 'woomp' ),
+	// 	'type'    => 'select',
+	// 	'class'   => 'wc-enhanced-select',
+	// 	'default' => '',
+	// 	'options' => [
+	// 		''           => __( 'N/A', 'woomp' ),
+	// 		'min_amount' => __( 'A minimum order amount', 'woomp' ),
+	// 	],
+	// ],
+	// 'free_shipping_min_amount' => [
+	// 	'title'       => __( 'Minimum order amount for free shipping', 'woomp' ),
+	// 	'type'        => 'price',
+	// 	'default'     => 0,
+	// 	'placeholder' => wc_format_localized_price( 0 ),
+	// 	'description' => __( 'Users will need to spend this amount to get free shipping.', 'woomp' ),
+	// 	'desc_tip'    => true,
+	// ],
 
 ];
 

--- a/includes/woomp-paynow-shipping/src/settings/settings-woomp-paynow-shipping-c2c-family-frozen.php
+++ b/includes/woomp-paynow-shipping/src/settings/settings-woomp-paynow-shipping-c2c-family-frozen.php
@@ -14,20 +14,20 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 $settings = [
 
-	'title'                    => [
+	'title' => [
 		'title'       => __( 'Title', 'woomp' ),
 		'type'        => 'text',
 		'description' => __( 'This controls the title which the user sees during checkout.', 'woomp' ),
 		'default'     => __( 'PayNow Shipping C2C Family Frozen', 'woomp' ),
 		'desc_tip'    => true,
 	],
-	'description'              => [
+	'description' => [
 		'title'       => __( 'Description', 'woomp' ),
 		'type'        => 'textarea',
 		'description' => __( 'This controls the description which the user sees during checkout.', 'woomp' ),
 		'desc_tip'    => true,
 	],
-	'measurement'              => [
+	'measurement' => [
 		'title'   => __( 'Shipping Measurement', 'woomp' ),
 		'type'    => 'select',
 		'class'   => 'wc-enhanced-select',
@@ -37,31 +37,53 @@ $settings = [
 			's105' => __( 's105', 'woomp' ),
 		],
 	],
-	'cost'                     => [
+	'cost' => [
 		'title'   => __( 'Shipping Cost', 'woomp' ),
 		'type'    => 'number',
 		'default' => 0,
 		'min'     => 0,
 		'step'    => 1,
 	],
-	'free_shipping_requires'   => [
-		'title'   => __( 'Free shipping requires', 'woomp' ),
+	'requires' => [
+		'title'   => __( 'Free shipping requires', 'woocommerce' ),
 		'type'    => 'select',
 		'class'   => 'wc-enhanced-select',
 		'default' => '',
 		'options' => [
-			''           => __( 'N/A', 'woomp' ),
-			'min_amount' => __( 'A minimum order amount', 'woomp' ),
+			''           => __( 'No requirement', 'woocommerce' ),
+			'coupon'     => __( 'A valid free shipping coupon', 'woocommerce' ),
+			'min_amount' => __( 'A minimum order amount', 'woocommerce' ),
+			'either'     => __( 'A minimum order amount OR coupon', 'woocommerce' ),
+			'both'       => __( 'A minimum order amount AND coupon', 'woocommerce' ),
 		],
 	],
-	'free_shipping_min_amount' => [
-		'title'       => __( 'Minimum order amount for free shipping', 'woomp' ),
+	'min_amount' => [
+		'title'       => __( 'Minimum order amount', 'ry-woocommerce-tools' ),
 		'type'        => 'price',
 		'default'     => 0,
 		'placeholder' => wc_format_localized_price( 0 ),
-		'description' => __( 'Users will need to spend this amount to get free shipping.', 'woomp' ),
+		'description' => __( 'Users will need to spend this amount to get free shipping (if enabled above).', 'woocommerce' ),
 		'desc_tip'    => true,
 	],
+	// 共用API使用的是'requires'
+	// 'free_shipping_requires'   => [
+	// 'title'   => __( 'Free shipping requires', 'woomp' ),
+	// 'type'    => 'select',
+	// 'class'   => 'wc-enhanced-select',
+	// 'default' => '',
+	// 'options' => [
+	// ''           => __( 'N/A', 'woomp' ),
+	// 'min_amount' => __( 'A minimum order amount', 'woomp' ),
+	// ],
+	// ],
+	// 'free_shipping_min_amount' => [
+	// 'title'       => __( 'Minimum order amount for free shipping', 'woomp' ),
+	// 'type'        => 'price',
+	// 'default'     => 0,
+	// 'placeholder' => wc_format_localized_price( 0 ),
+	// 'description' => __( 'Users will need to spend this amount to get free shipping.', 'woomp' ),
+	// 'desc_tip'    => true,
+	// ],
 
 ];
 

--- a/includes/woomp-paynow-shipping/src/shippings/class-woomp-paynow-shipping-c2c-711-frozen.php
+++ b/includes/woomp-paynow-shipping/src/shippings/class-woomp-paynow-shipping-c2c-711-frozen.php
@@ -44,13 +44,15 @@ class WOOMP_PayNow_Shipping_C2C_711_Frozen extends PayNow_Abstract_Shipping_Meth
 		$this->instance_form_fields = include WOOMP_PAYNOW_SHIPPING_PLUGIN_DIR . 'src/settings/settings-woomp-paynow-shipping-c2c-711-frozen.php';
 		$this->init_settings();
 
-		$this->title                    = $this->get_option( 'title' );
-		$this->cost                     = $this->get_option( 'cost' );
-		$this->free_shipping_requires   = $this->get_option( 'free_shipping_requires' );
-		$this->free_shipping_min_amount = $this->get_option( 'free_shipping_min_amount', 0 );
-		$this->type                     = $this->get_option( 'type', 'class' );
-		$this->max_amount               = 20000;
-		$this->supports                 = [
+		$this->title      = $this->get_option( 'title' );
+		$this->cost       = $this->get_option( 'cost' );
+		$this->requires   = $this->get_option( 'requires' );
+		$this->min_amount = $this->get_option( 'min_amount', 0 );
+		// $this->free_shipping_requires   = $this->get_option( 'free_shipping_requires' );
+		// $this->free_shipping_min_amount = $this->get_option( 'free_shipping_min_amount', 0 );
+		$this->type       = $this->get_option( 'type', 'class' );
+		$this->max_amount = 20000;
+		$this->supports   = [
 			'shipping-zones',
 			'instance-settings',
 			'instance-settings-modal',

--- a/includes/woomp-paynow-shipping/src/shippings/class-woomp-paynow-shipping-c2c-family-frozen.php
+++ b/includes/woomp-paynow-shipping/src/shippings/class-woomp-paynow-shipping-c2c-family-frozen.php
@@ -44,14 +44,16 @@ class WOOMP_PayNow_Shipping_C2C_Family_Frozen extends PayNow_Abstract_Shipping_M
 		$this->instance_form_fields = include WOOMP_PAYNOW_SHIPPING_PLUGIN_DIR . 'src/settings/settings-woomp-paynow-shipping-c2c-family-frozen.php';
 		$this->init_settings();
 
-		$this->title                    = $this->get_option( 'title' );
-		$this->measurement              = $this->get_option( 'measurement', 's60' );
-		$this->cost                     = $this->get_option( 'cost' );
-		$this->free_shipping_requires   = $this->get_option( 'free_shipping_requires' );
-		$this->free_shipping_min_amount = $this->get_option( 'free_shipping_min_amount', 0 );
-		$this->type                     = $this->get_option( 'type', 'class' );
-		$this->max_amount               = 20000;
-		$this->supports                 = [
+		$this->title       = $this->get_option( 'title' );
+		$this->measurement = $this->get_option( 'measurement', 's60' );
+		$this->cost        = $this->get_option( 'cost' );
+		$this->requires    = $this->get_option( 'requires' );
+		$this->min_amount  = $this->get_option( 'min_amount', 0 );
+		// $this->free_shipping_requires   = $this->get_option( 'free_shipping_requires' );
+		// $this->free_shipping_min_amount = $this->get_option( 'free_shipping_min_amount', 0 );
+		$this->type       = $this->get_option( 'type', 'class' );
+		$this->max_amount = 20000;
+		$this->supports   = [
 			'shipping-zones',
 			'instance-settings',
 			'instance-settings-modal',


### PR DESCRIPTION
原本的冷凍超取功能是失效的
因為key值與共用class的key值不相同