### PR TITLE
fix: 移除綠界信用卡分期付款結帳頁重複的描述輸出

### DIFF
--- a/includes/ry-woocommerce-tools/woocommerce/gateways/ecpay/ecpay-gateway-credit-installment.php
+++ b/includes/ry-woocommerce-tools/woocommerce/gateways/ecpay/ecpay-gateway-credit-installment.php
@@ -40,10 +40,6 @@ class RY_ECPay_Gateway_Credit_Installment extends RY_ECPay_Gateway_Base {
 
 	public function payment_fields() {
 		parent::payment_fields();
-		$description = $this->get_description();
-		if ( $description ) {
-			echo wpautop( wptexturize( $description ) );
-		}
 		echo '<p>' . _x( 'Number of periods', 'Checkout info', 'ry-woocommerce-tools' );
 		echo ' <select name="ecpay_number_of_periods">';
 		foreach ( $this->number_of_periods as $number_of_periods ) {


### PR DESCRIPTION
Closes #95

## Summary

`RY_ECPay_Gateway_Credit_Installment::payment_fields()` 已透過 `parent::payment_fields()` 輸出 description，下方又用 `get_description()` + `wpautop` 印一次，造成結帳頁顯示兩個描述。本 PR 移除該段重複輸出（4 行）。

## Change

`includes/ry-woocommerce-tools/woocommerce/gateways/ecpay/ecpay-gateway-credit-installment.php`：
- 移除 `payment_fields()` 中重複呼叫 `get_description()` + `wpautop( wptexturize( ... ) )` 的 4 行

## Test plan

- [ ] 後台啟用「綠界信用卡分期付款」並填寫描述
- [ ] 前台結帳頁選擇該付款方式 → 確認描述只出現一次
- [ ] 確認分期下拉選單仍正常顯示
- [ ] 確認其它分期版本（3/6/12/18/24 期）顯示無回歸