### PR TITLE
feat: 訂單列表批次操作新增「變更為已出貨／配送中」(#97)

### DIFF
--- a/admin/class-woomp-order.php
+++ b/admin/class-woomp-order.php
@@ -425,6 +425,9 @@ if ( ! class_exists( 'WooMP_Order' ) ) {
 		 * @return array 更新後的批次處理選項
 		 */
 		public function bulk_action( $actions ) {
+			$actions['mark_wmp-shipped']    = __( '變更為已出貨', 'woomp' );
+			$actions['mark_wmp-in-transit'] = __( '變更為配送中', 'woomp' );
+
 			if ( ! wc_string_to_bool( get_option( 'RY_WT_enabled_ecpay_shipping' ) ) ) {
 				return $actions;
 			}
@@ -444,9 +447,6 @@ if ( ! class_exists( 'WooMP_Order' ) ) {
 			}
 
 			$actions['ry_print_ecpay_home_tcat'] = __( 'Print ECPay shipping booking note (tcat)', 'woomp' );
-
-			$actions['mark_wmp-shipped']    = __( '變更為已出貨', 'woomp' );
-			$actions['mark_wmp-in-transit'] = __( '變更為配送中', 'woomp' );
 
 			return $actions;
 		}


### PR DESCRIPTION
Close #97

## Summary

- 將 \`mark_wmp-shipped\`、\`mark_wmp-in-transit\` 兩個批次動作移出 ECPay guard，讓未啟用綠界物流的商家在訂單列表也能直接批次切換狀態。
- 綠界列印類批次動作維持原本的 gate 行為不變。
- 處理邏輯 \`handle_bulk_order_status_update()\` 原本就不依賴 ECPay，無需改動。

## Test plan

- [ ] 停用綠界物流，確認訂單列表「批次操作」下拉顯示「變更為已出貨」「變更為配送中」
- [ ] 啟用綠界物流，確認兩個狀態選項仍顯示，且綠界列印選項維持
- [ ] 勾選多筆訂單 → 套用「變更為已出貨」→ 訂單狀態正確切至 \`wmp-shipped\`
- [ ] 勾選多筆訂單 → 套用「變更為配送中」→ 訂單狀態正確切至 \`wmp-in-transit\`
- [ ] 頂部 admin notice 顯示「N 筆訂單已更新為 已出貨／配送中」

🤖 Generated with [Claude Code](https://claude.com/claude-code)