### PR TITLE
fix: 綠界金流被 WC Blocks 在 init:5 搶先初始化導致消失 (#99)

### DIFF
--- a/init.php
+++ b/init.php
@@ -128,7 +128,10 @@ if ( ! defined( 'RY_WT_VERSION' ) ) {
 
 	register_activation_hook( __FILE__, [ 'RY_WT', 'plugin_activation' ] );
 	register_deactivation_hook( __FILE__, [ 'RY_WT', 'plugin_deactivation' ] );
-	add_action( 'init', [ 'RY_WT', 'ry_init' ] );
+	// 改用 plugins_loaded 載入，避免 WooCommerce Blocks 在 init:5 提前
+	// 初始化 WC_Payment_Gateways 後，綠界 gateway 的 add_filter 來不及生效。
+	// 詳見 issue #99。
+	add_action( 'plugins_loaded', [ 'RY_WT', 'ry_init' ], 20 );
 	add_action( 'init', [ 'RY_WT', 'load_plugin_textdomain_ry_woocommerce_tools' ] );
 
 }


### PR DESCRIPTION
Fixes #99

## 變更

把 `RY_WT::ry_init` 的 hook 從 `init` (priority 10) 改成 `plugins_loaded` (priority 20)。

```diff
- add_action( 'init', [ 'RY_WT', 'ry_init' ] );
+ add_action( 'plugins_loaded', [ 'RY_WT', 'ry_init' ], 20 );
```

`load_plugin_textdomain_*` 仍保留在 `init` hook（這是 WP 規範要求的位置）。

## 為什麼要改

`Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry::initialize` 在 `init` priority 5 就會觸發 `WC()->payment_gateways()->payment_gateways()`，把當下的 gateway 清單鎖進 singleton cache。

woomp 原本在 `init` priority 10 才載入 ECPay gateway 並掛 `add_filter('woocommerce_payment_gateways', ...)`，filter 雖然有掛，但 WC 已經不會再跑 filter，11 個綠界 gateway 永遠不會被加進清單。

改到 `plugins_loaded` priority 20 後，filter 在 WC Blocks 提前 init 之前就掛好，從根本上避開 race condition。

## 為什麼選 plugins_loaded:20

- WooCommerce 主檔在 `plugins_loaded` priority 0 載入，`WC_VERSION` 立刻定義
- `is_admin()` 在更早時機就 ready
- priority 20 比 WC 內部初始化晚，足以安全使用 WC API
- 比 `init` 早，不會被任何 init hook 監聽者搶先

`RY_WT::ry_init()` 內依賴的 `WC_VERSION`、`is_admin()`、`get_option()` 在這個時機都可用。

## 重現條件（三者同時滿足）

1. 使用 woomp（非獨立 ry-woocommerce-tools）
2. WooCommerce ≥ 7.x（有 PaymentMethodRegistry）
3. 站台會觸發 WC Blocks 結帳/購物車（如使用 power-checkout 或 Cart/Checkout block）

## 驗證

實測 appareltherapist.com（woomp 3.4.81 + WC 10.3.8 + power-checkout）：

| 項目 | 套用前 | 套用後 |
|---|---|---|
| 註冊閘道總數 | 19 | 30 |
| 綠界閘道 | 0 | 11 全到位 |
| 既有閘道（PAYUNi、Shopline、LINE Pay…） | 19 | 19（無破壞） |
| PHP 錯誤 | — | 無 |

註：實測時是用 mu-plugin 在 init:11 強制 reset+reinit 驗證效果，本 PR 改 hook 是更乾淨的根本解。