### PR TITLE
fix: PayUni V3 SettingDTO 憑證未設定時 fatal (closes #104)

### DIFF
--- a/includes/payuni/v3/Contracts/DTOs/SettingDTO.php
+++ b/includes/payuni/v3/Contracts/DTOs/SettingDTO.php
@@ -61,15 +61,15 @@ final class SettingDTO {
                 ) : [],
                 'enable_tokenization'  => \wc_string_to_bool( $gateway_settings['enable_tokenization'] ?? 'no' ),
                 'enable_invoice_carrier' => \wc_string_to_bool( $gateway_settings['enable_invoice_carrier'] ?? 'no' ),
-                'merchant_id'         => $is_test ? \get_option( 'payuni_payment_merchant_no_test' ) : \get_option(
-                    'payuni_payment_merchant_no'
-                ),
-                'hash_key'            => $is_test ? \get_option( 'payuni_payment_hash_key_test' ) : \get_option(
-                    'payuni_payment_hash_key'
-                ),
-                'hash_iv'             => $is_test ? \get_option( 'payuni_payment_hash_iv_test' ) : \get_option(
-                    'payuni_payment_hash_iv'
-                ),
+                'merchant_id'         => (string) ( $is_test ? \get_option( 'payuni_payment_merchant_no_test', '' ) : \get_option(
+                    'payuni_payment_merchant_no', ''
+                ) ),
+                'hash_key'            => (string) ( $is_test ? \get_option( 'payuni_payment_hash_key_test', '' ) : \get_option(
+                    'payuni_payment_hash_key', ''
+                ) ),
+                'hash_iv'             => (string) ( $is_test ? \get_option( 'payuni_payment_hash_iv_test', '' ) : \get_option(
+                    'payuni_payment_hash_iv', ''
+                ) ),
             ];
             
             self::$instance = new self( $args );


### PR DESCRIPTION
Closes #104

## 問題
PayUni V3 在使用者**沒有設定**統一金流憑證時，任何觸發 `is_checkout()` 為 true 的頁面（結帳頁、訂單完成頁）會整頁 500「發生嚴重錯誤」。

## 根因
`includes/payuni/v3/Contracts/DTOs/SettingDTO.php` 第 64-72 行使用 `\get_option()` 但沒帶預設值。
WordPress 的 `get_option( $name )` 對未設定的 option 回傳 `false`。
DTO 屬性宣告為嚴格型別 `public string $merchant_id|$hash_key|$hash_iv`（檔頭 `declare(strict_types=1)`），
PHP 8 在賦值時直接拋 TypeError，由 `Bootstrap::enqueue_checkout_scripts()` 經 `wp_enqueue_scripts` hook 帶上整頁 fatal。

## 修補
對六處 `\get_option()` 加上 `''` 預設值；外層再 `(string)` 強轉，
覆蓋 option 曾被存成非字串標量（false / 0 / null）的邊角情境。

## 測試
- 站台 `treeman.tw` 已先以同一份 patch 熱修，從 patch 上線 (UTC 05:24) 後 fatal-errors log 不再有 `Cannot assign bool` 條目。
- diff 僅限這三組賦值，不動其他行為。

## 仍待處理（不在此 PR 範圍）
Issue #104 還列了第二個結構性問題：`payuni/payuni.php:16-27` 的 `Bootstrap::register_hooks()` 寫在 `if ( wc_woomp_enabled_payuni_gateway )` 區塊外，導致使用者關閉 PayUni 時 V3 hook 仍會註冊。
建議另開 PR 把 `register_hooks()` 移進 `if` 內或在 `register_hooks()` 自我守衛。

🤖 Generated with [Claude Code](https://claude.com/claude-code)