### PR TITLE
fix: PayUni V3 hook 在關閉 PayUni 時仍註冊導致後台 fatal (closes #106)

### DIFF
--- a/includes/payuni/payuni.php
+++ b/includes/payuni/payuni.php
@@ -20,10 +20,11 @@ add_action(
 				wp_die( 'WC_Payment_Gateway not found' );
 			}
 			\PAYUNI\APIs\Payment::init();
+
+			// 註冊統一金流 v3 入口；V3 程式碼會跨 namespace 引用 PAYUNI\Gateways\* (V1)，
+			// 必須與 V1 src autoload 同步啟用，否則後台訂單頁等 hook 會 fatal Class not found。
+			Bootstrap::register_hooks();
 		}
-        
-        // 註冊統一金流 v3 入口
-        Bootstrap::register_hooks();
 	}
 );
 


### PR DESCRIPTION
Closes #106

延續 #104 第二段已點出但未在 #105 修補的結構性問題。

## 問題
站台**未啟用**統一金流（`wc_woomp_enabled_payuni_gateway` 與 `wc_woomp_enabled_payuni_shipping` 皆 false）時，後台進入任一筆訂單編輯頁會整頁 500：

```
Uncaught Error: Class "PAYUNI\Gateways\CreditSubscriptionV3" not found
in includes/payuni/v3/Domains/Subscription/SubscriptionMetabox.php:88
```

## 根因
`includes/payuni/payuni.php`：

```php
if ( wc_woomp_enabled_payuni_gateway || wc_woomp_enabled_payuni_shipping ) {
    \A7\autoload( ... 'includes/payuni/src' );  // ← V1 namespace 的 autoload 只在這裡註冊
    \PAYUNI\APIs\Payment::init();
}

// V3 入口在 if 之外 —— PayUni 關閉時仍會跑
Bootstrap::register_hooks();
```

V3 程式碼跨 namespace 引用 V1 class，包含：
- `v3/Bootstrap.php:174` — `\PAYUNI\Gateways\CreditSubscriptionV3::ID`
- `v3/Domains/Subscription/SubscriptionMetabox.php:15,88`
- `v3/Domains/Subscription/SubscriptionHandler.php:18`

當 PayUni toggle 關閉時，`\A7\autoload(...)` 沒註冊 → V1 class 無法載入 → 任何觸發 V3 hook 的場景就 fatal。後台訂單頁是日常會踩到的入口。

## 修補
把 `Bootstrap::register_hooks()` 搬進 `if` 區塊內，與 V1 src autoload + `Payment::init()` 同步啟用。

語意上也合理 —— 使用者在 woomp 設定關閉 PayUni 時，本來就不應該有任何 PayUni 相關 hook 還在跑。

## 影響
- 用其他金流（如 ECPay）、沒設定 PayUni 的站台不再因為打開後台訂單頁而 fatal
- 沒改任何啟用 PayUni 站台的行為（`if` 裡的 V1 init 流程不變、V3 register_hooks 仍會跑，且必跟 V1 autoload 一起）

🤖 Generated with [Claude Code](https://claude.com/claude-code)