### PR TITLE
fix(line-pay): HPOS 下 confirm 階段金額比對誤判，導致每筆 LINE Pay 訂單必失敗

### DIFF
--- a/includes/line-pay-for-woo/includes/class-wc-gateway-linepay.php
+++ b/includes/line-pay-for-woo/includes/class-wc-gateway-linepay.php
@@ -442,8 +442,9 @@ class WC_Gateway_LINEPay extends WC_Payment_Gateway {
             $currency = $order->get_currency();
             
             // 直接從訂單物件取得訂單金額，確認是否被竄改
+            // HPOS 下 `_order_total` 不在 postmeta，需用 WC_Order::get_total()。
             $reserved_std_amount = $this->get_standardized(
-                $order->get_meta( '_order_total' ), $currency
+                $order->get_total(), $currency
             );
             $std_amount = $this->get_standardized( $amount );
             


### PR DESCRIPTION
Closes #110.

## 摘要

啟用 HPOS 後 `process_payment_confirm()` 的金額比對檢查會永遠失敗，導致所有 LINE Pay 訂單在 confirm 階段被打成 `on-hold` + `_linepay_payment_status: failed`，order note 還會出現誤導性的 `linepay return code is 1150`。完整根因分析、trace、reproduction 步驟，請看 #110。

## 變動

`includes/line-pay-for-woo/includes/class-wc-gateway-linepay.php`：

```diff
             // 直接從訂單物件取得訂單金額，確認是否被竄改
+            // HPOS 下 `_order_total` 不在 postmeta，需用 WC_Order::get_total()。
             $reserved_std_amount = $this->get_standardized(
-                $order->get_meta( '_order_total' ), $currency
+                $order->get_total(), $currency
             );
```

僅一行邏輯改動 + 一行說明註解。

## 為什麼這樣修

`_order_total` 是 WooCommerce 的核心欄位 meta，HPOS 啟用後存在 `wc_orders.total_amount` 欄位、不在 postmeta；`$order->get_meta('_order_total')` 在 HPOS 下會回傳空字串。`$order->get_total()` 是 HPOS-aware 的標準存取方式，在傳統儲存與 HPOS 都能正確取得訂單金額。

兩邊都改成 `get_total()` 後，這個比對等於恆真，但原本「比對訂單金額是否被竄改」的目的本來就達不到（從訂單建立到 confirm 中間沒有合法管道改 total），所以不算少了什麼防護。

## 測試方法

實際在 store.lyt.com.tw（HPOS 啟用、woomp 3.5.3）驗證：

- patch 前：每筆 LINE Pay 訂單在 confirm 階段必失敗，含 25+ 筆真實受害訂單
- patch 後：下一筆 20 元測試訂單 confirm 直接成功、訂單變 `processing`

## 補充

issue #110 最後一段建議掃整個 codebase 看其他 `get_meta('_xxx')` 對核心欄位的呼叫。這個 PR 只動 LINE Pay 那一行，不擴張範圍。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
