### PR TITLE
fix: PayUni V3 訂閱閘道過濾器在非結帳頁也運行 (#114)

### DIFF
--- a/includes/payuni/v3/Domains/Subscription/SubscriptionBootstrap.php
+++ b/includes/payuni/v3/Domains/Subscription/SubscriptionBootstrap.php
@@ -94,6 +94,14 @@ final class SubscriptionBootstrap {
 	 * @return array 過濾後的付款閘道
 	 */
 	public static function conditional_payment_gateways( array $available_gateways ): array {
+		// 僅在結帳流程中依購物車內容過濾訂閱閘道。
+		// 在 My Account → 新增付款方式 / 管理付款方式 等頁面，
+		// 購物車通常為空或不含訂閱商品，過濾會把 V1/V3 全部移除，
+		// 導致用戶看不到任何信用卡欄位、無法新增或更換卡片。
+		if ( ! \is_checkout() ) {
+			return $available_gateways;
+		}
+
 		// 收集購物車中的商品類型
 		$product_types = self::get_cart_product_types();
 

--- a/tests/phpunit/integration/SubscriptionV3BootstrapTest.php
+++ b/tests/phpunit/integration/SubscriptionV3BootstrapTest.php
@@ -261,4 +261,50 @@ final class SubscriptionV3BootstrapTest extends WP_UnitTestCase {
 			'一般商品應保留一般信用卡閘道'
 		);
 	}
+
+	// ──────────────────────────────────────────────
+	// 5. 非結帳頁面不應過濾訂閱閘道（#114）
+	// ──────────────────────────────────────────────
+
+	/**
+	 * @testdox 非結帳頁面（例如 My Account 新增付款方式）不應移除訂閱閘道
+	 *
+	 * Regression test for #114: 修正前 conditional_payment_gateways 沒有
+	 * is_checkout() 保護，導致在 /my-account/add-payment-method/ 頁面，
+	 * V1 和 V3 訂閱閘道會被一併移除，用戶看不到任何信用卡欄位、無法新增
+	 * 或更換付款方式。
+	 */
+	public function test_keeps_subscription_gateways_outside_checkout(): void {
+		$previous = error_reporting( E_ALL & ~E_DEPRECATED );
+		$gateways = [
+			'payuni-credit-v3'               => new \PAYUNI\Gateways\CreditV3(),
+			'payuni-credit-subscription'     => new \PAYUNI\Gateways\CreditSubscription(),
+			'payuni-credit-subscription-v3'  => new \PAYUNI\Gateways\CreditSubscriptionV3(),
+		];
+		error_reporting( $previous );
+
+		// PHPUnit 預設不是 checkout context，所以 is_checkout() 回傳 false
+		$this->assertFalse(
+			is_checkout(),
+			'測試前提：當前不是 checkout 頁面'
+		);
+
+		$result = \J7\Payuni\Domains\Subscription\SubscriptionBootstrap::conditional_payment_gateways( $gateways );
+
+		$this->assertArrayHasKey(
+			'payuni-credit-subscription',
+			$result,
+			'非結帳頁應保留 V1 訂閱閘道（讓用戶能在 My Account 新增付款方式）'
+		);
+		$this->assertArrayHasKey(
+			'payuni-credit-subscription-v3',
+			$result,
+			'非結帳頁應保留 V3 訂閱閘道（讓用戶能在 My Account 新增付款方式）'
+		);
+		$this->assertArrayHasKey(
+			'payuni-credit-v3',
+			$result,
+			'非結帳頁應保留一般信用卡閘道'
+		);
+	}
 }


### PR DESCRIPTION
Closes #114

## Summary

修正 PayUni V3 定期定額閘道啟用後，使用者在 **My Account → 新增付款方式** 頁面看不到任何信用卡欄位、無法新增或更換信用卡的問題。

## 問題

`SubscriptionBootstrap::conditional_payment_gateways()` 缺少 `is_checkout()` 保護，所有頁面（含 My Account → Add Payment Method、訂閱換卡前的入口頁等）都會跑「購物車內無訂閱商品則移除 V1 + V3 訂閱閘道」的過濾邏輯。

在 \`/my-account/add-payment-method/\`：

- 購物車空的（或裡面是一般商品）
- Filter 把 V1 + V3 訂閱閘道全部移除
- 若站點僅啟用 V3 訂閱，剩 0 個可用 gateway
- WC 顯示「New payment methods can only be added during checkout」或空白 → 用戶無法新增卡片

對照 V1 \`PAYUNI\\Gateways\\Subscription::conditional_payment_gateways()\` 本來就有 \`is_checkout()\` 守門，V3 改寫時漏掉。

## 解法

在 \`conditional_payment_gateways()\` 開頭加 \`is_checkout()\` 早退：

\`\`\`php
public static function conditional_payment_gateways( array \$available_gateways ): array {
    if ( ! \\is_checkout() ) {
        return \$available_gateways;
    }
    // ...原本邏輯
}
\`\`\`

WC 的 \`is_checkout()\` 在以下情境都會回傳 true：
- \`/checkout/\` 結帳頁
- \`/checkout/order-pay/{id}/\` 訂單付款頁
- \`/checkout/order-pay/{id}/?change_payment_method=...\` 訂閱換卡流程
- 任何掛 \`[woocommerce_checkout]\` shortcode 的頁面
- 定義 \`WOOCOMMERCE_CHECKOUT\` 常數的上下文

→ 真正需要根據購物車內容過濾的場景都有覆蓋。

非結帳頁（My Account、商品頁、後台、wp-cron…）則跳過過濾，所有啟用的 gateway 正常顯示。

## Regression test

新增 \`test_keeps_subscription_gateways_outside_checkout\`：

- 模擬 V1 + V3 + 一般信用卡三個 gateway 並存
- 在 PHPUnit 預設 context（\`is_checkout() === false\`）呼叫 \`conditional_payment_gateways()\`
- 驗證三個 gateway 都仍在結果裡，沒有被誤殺

既有測試（\`filter_gateways_by_cart\` 系列）不受影響，因為它們直接測底層方法，繞過 \`is_checkout()\` 守門。

## Test plan

- [ ] 啟用 \`PayUni V3 定期定額 (payuni-credit-subscription-v3)\`，啟用 WC Subscriptions
- [ ] 以普通會員登入前台
- [ ] 進入 \`/my-account/add-payment-method/\`
- [ ] 確認看到 PayUni V3 定期定額（或其他啟用的信用卡 gateway）選項與 CC 欄位
- [ ] 結帳流程驗證：
  - [ ] 購物車放一般商品 → 結帳頁不顯示 V1/V3 訂閱閘道（既有行為不變）
  - [ ] 購物車放 subscription 商品 → 結帳頁顯示訂閱閘道
  - [ ] 購物車放 variable-subscription 商品 → 結帳頁顯示訂閱閘道
- [ ] 訂閱換卡流程：從 My Account → Subscriptions 點「Change payment method」可正常進入 \`/checkout/order-pay/...\` 並看到 V3 選項
- [ ] phpunit 整合測試通過：\`vendor/bin/phpunit tests/phpunit/integration/SubscriptionV3BootstrapTest.php\`

## 影響範圍

- 純前端條件邏輯修正，不動 process_payment、token 處理、API 呼叫
- 不影響 V1 訂閱閘道（它有自己的 \`is_checkout()\` 守門）
- 不影響結帳頁訂閱商品過濾行為（is_checkout() 為 true 時邏輯不變）

🤖 Generated with [Claude Code](https://claude.com/claude-code)