### PR TITLE
fix(checkout): support Blocksy 2.x wrapper & hide empty PayUni rows

### DIFF
--- a/includes/payuni/v3/Shared/Utils/OrderUtils.php
+++ b/includes/payuni/v3/Shared/Utils/OrderUtils.php
@@ -80,20 +80,28 @@ final class OrderUtils {
     
     /** 擴展暫存資料欄位 */
     public static function extend_checkout_field( array $fields ): array {
+        // 加上 .hidden class，避免 WooCommerce 將 hidden input 包進 <p class="form-row"> 後
+        // 仍占用版面（每個 <p> 約 27px 高度，5 個就會在表單裡產生 ~135px 空白）。
+        // .hidden 在本外掛 form-checkout.php 已定義 display: none !important。
         $fields['billing']['sdk_token_tmp'] = [
-            'type' => 'hidden',
+            'type'  => 'hidden',
+            'class' => [ 'hidden' ],
         ];
         $fields['billing']['payuni_save_card'] = [
-            'type' => 'hidden',
+            'type'  => 'hidden',
+            'class' => [ 'hidden' ],
         ];
         $fields['billing']['payuni_installment'] = [
-            'type' => 'hidden',
+            'type'  => 'hidden',
+            'class' => [ 'hidden' ],
         ];
         $fields['billing']['payuni_use_saved_token'] = [
-            'type' => 'hidden',
+            'type'  => 'hidden',
+            'class' => [ 'hidden' ],
         ];
         $fields['billing']['payuni_saved_token_id'] = [
-            'type' => 'hidden',
+            'type'  => 'hidden',
+            'class' => [ 'hidden' ],
         ];
         return $fields;
     }

--- a/woocommerce/checkout/form-checkout.php
+++ b/woocommerce/checkout/form-checkout.php
@@ -141,15 +141,21 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 		display: flex;
 		flex-wrap: wrap;
 	}
-	form.checkout.woocommerce-checkout #customer_details {
+	form.checkout.woocommerce-checkout #customer_details,
+	form.checkout.woocommerce-checkout > .ct-customer-details {
 		order: 2;
 		width: 100%!important;
+		max-width: 100%!important;
+		flex: 1 1 100%!important;
 		float: none!important;
 		margin-right: 0!important;
 	}
-	form.checkout.woocommerce-checkout #order_review {
+	form.checkout.woocommerce-checkout #order_review,
+	form.checkout.woocommerce-checkout > .ct-order-review {
 		order: 1;
 		width: 100%!important;
+		max-width: 100%!important;
+		flex: 1 1 100%!important;
 		float: none!important;
 		margin-left: 0!important;
 		padding: 0!important;


### PR DESCRIPTION
Closes #116

## Summary

- form-checkout.php inline `<style>` 的選擇器同時保留舊版 `#customer_details` / `#order_review` 與 Blocksy 2.x wrapper `.ct-customer-details` / `.ct-order-review`，並加 `max-width: 100%` + `flex: 1 1 100%` 確保 flex item 占整行。
- PayUni V3 `OrderUtils::extend_checkout_field` 注入的 5 個 hidden 欄位補上 `class: ['hidden']`，套用本外掛既有的 `.hidden { display: none !important; }` 規則，避免 WooCommerce 把 `type: hidden` 包進的 `<p class=\"form-row\">` 在版面占用 ~27px × 5 = 135px。

完整跑版分析與 DOM error log 見 #116。

## Test plan

- [x] Blocksy 2.1.34 + WooCommerce 10.7.0 + woomp 3.5.4 + Subscriptions + PayUni V3 Credit Subscription：實機驗證 `erictangservice.com` 結帳頁排版恢復正常、聯絡電話與密碼欄位之間無大空白。
- [ ] 在使用其他主題（Astra / Avada / Woodmart / 預設 Twenty 系列）的環境再次驗證沒有 regression。
- [ ] 非訂閱、非 PayUni 的單純結帳流程驗證隱藏欄位邏輯仍正常運作（送出後 order meta 仍能寫入）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)