### PR TITLE
fix(paynow-einvoice): remove ext-soap dependency & populate carrier_id for easycard/cdc

### DIFF
--- a/includes/paynow-einvoice/includes/class-paynow-einvoice.php
+++ b/includes/paynow-einvoice/includes/class-paynow-einvoice.php
@@ -407,8 +407,12 @@ class Paynow_Einvoice {
 				$selected_carrier_type = $order->get_meta( '_paynow_ei_carrier_type' );
 				if ( $selected_carrier_type === 'ei_carrier_type_easycard_code' ) {
 					$carrier_type = '1K0001'; // 悠遊卡
+					$carrier_id1  = $order->get_meta( '_paynow_ei_carrier_num' );
+					$carrier_id2  = $carrier_id1;
 				} elseif ( $selected_carrier_type === 'ei_carrier_type_cdc_code' ) {
 					$carrier_type = 'CQ0001'; // 自然人憑證
+					$carrier_id1  = $order->get_meta( '_paynow_ei_carrier_num' );
+					$carrier_id2  = $carrier_id1;
 				} elseif ( $selected_carrier_type === 'ei_carrier_type_mobile_code' ) {
 					$carrier_type = '3J0002'; // 通用載具
 					$carrier_id1  = $order->get_meta( '_paynow_ei_carrier_num' );

--- a/includes/paynow-einvoice/includes/class-paynow-einvoice.php
+++ b/includes/paynow-einvoice/includes/class-paynow-einvoice.php
@@ -477,25 +477,71 @@ class Paynow_Einvoice {
 		return $result;
 	}
 
+	/**
+	 * SOAP 1.2 over plain HTTP — avoids dependency on PHP ext-soap.
+	 *
+	 * Mimics SoapClient::__soapCall return shape for simple operations whose
+	 * inputs are flat scalar parameters and output is a single string result.
+	 *
+	 * @param string               $method SOAP operation name (e.g. UploadInvoice_Patch).
+	 * @param array<string,string> $params Flat string parameters.
+	 * @return \stdClass Object with `$method . 'Result'` property holding the response string.
+	 * @throws \Exception When the HTTP request fails or the response cannot be parsed.
+	 */
+	private function pn_soap_post( $method, $params ) {
+		$ns       = 'https://invoice.PayNow.com.tw/';
+		$endpoint = $this->api_url . '/PayNowEInvoice.asmx';
+
+		$param_xml = '';
+		foreach ( $params as $key => $value ) {
+			$param_xml .= sprintf(
+				'<%1$s>%2$s</%1$s>',
+				$key,
+				htmlspecialchars( (string) $value, ENT_XML1 | ENT_QUOTES, 'UTF-8' )
+			);
+		}
+		$envelope = '<?xml version="1.0" encoding="utf-8"?>'
+			. '<soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">'
+			. '<soap12:Body><' . $method . ' xmlns="' . $ns . '">' . $param_xml . '</' . $method . '></soap12:Body>'
+			. '</soap12:Envelope>';
+
+		$response = \wp_remote_post(
+			$endpoint,
+			[
+				'timeout'   => 30,
+				'headers'   => [ 'Content-Type' => 'application/soap+xml; charset=utf-8' ],
+				'body'      => $envelope,
+				'sslverify' => false,
+			]
+		);
+
+		if ( \is_wp_error( $response ) ) {
+			throw new \Exception( 'PayNow SOAP request failed: ' . $response->get_error_message() );
+		}
+
+		$code = \wp_remote_retrieve_response_code( $response );
+		$body = \wp_remote_retrieve_body( $response );
+		if ( 200 !== (int) $code ) {
+			throw new \Exception( 'PayNow SOAP HTTP ' . $code . ': ' . substr( (string) $body, 0, 200 ) );
+		}
+
+		$prev_errors = libxml_use_internal_errors( true );
+		$xml         = simplexml_load_string( (string) $body );
+		libxml_use_internal_errors( $prev_errors );
+		if ( false === $xml ) {
+			throw new \Exception( 'PayNow SOAP invalid XML response: ' . substr( (string) $body, 0, 200 ) );
+		}
+
+		$xml->registerXPathNamespace( 'pn', $ns );
+		$nodes        = $xml->xpath( '//pn:' . $method . 'Result' );
+		$result_value = ( ! empty( $nodes ) ) ? (string) $nodes[0] : '';
+
+		$obj                       = new \stdClass();
+		$obj->{$method . 'Result'} = $result_value;
+		return $obj;
+	}
+
 	private function do_issue( $ei_datas ) {
-		$context_options = [
-			'ssl' => [
-				'verify_peer'       => false,
-				'verify_peer_name'  => false,
-				'allow_self_signed' => true,
-				'crypto_method'     => STREAM_CRYPTO_METHOD_TLS_CLIENT,
-			],
-		];
-		$options         = [
-			'soap_version'   => SOAP_1_2,
-			'exceptions'     => true,
-			'trace'          => 1,
-			'cache_wsdl'     => WSDL_CACHE_NONE,
-			'stream_context' => stream_context_create( $context_options ),
-		];
-
-		$client = new \SoapClient( $this->api_url . '/PayNowEInvoice.asmx?wsdl', $options );
-
 		$str = $this->build_invoice_str( $ei_datas );
 		// $this->pn_write_log( 'csvStr:' . $str );
 
@@ -508,7 +554,7 @@ class Paynow_Einvoice {
 		];
 
 		// $this->pn_write_log( $param_ary );
-		$aryResult = $client->__soapCall( 'UploadInvoice_Patch', [ 'parameters' => $param_ary ] );
+		$aryResult = $this->pn_soap_post( 'UploadInvoice_Patch', $param_ary );
 		// $this->pn_write_log( '====>UploadInvoice_Patch' );
 		// $this->pn_write_log( $aryResult );
 		$result = $aryResult->UploadInvoice_PatchResult;
@@ -534,37 +580,15 @@ class Paynow_Einvoice {
 	 *
 	 * @param string $invoice_no 發票號碼
 	 * @return string 'S' | 'F_XXXXXXXXXX'
-	 * @throws \Exception SoapClient class not found.
+	 * @throws \Exception When the HTTP request to PayNow fails.
 	 */
 	private function cancel_invoice( string $invoice_no ): string {
-		$context_options = [
-			'ssl' => [
-				'verify_peer'       => false,
-				'verify_peer_name'  => false,
-				'allow_self_signed' => true,
-				'crypto_method'     => STREAM_CRYPTO_METHOD_TLS_CLIENT,
-			],
-		];
-		$options         = [
-			'soap_version'   => SOAP_1_2,
-			'exceptions'     => true,
-			'trace'          => 1,
-			'cache_wsdl'     => WSDL_CACHE_NONE,
-			'stream_context' => stream_context_create( $context_options ),
-		];
-
 		$params = [
 			'mem_cid'   => $this->mem_cid,
 			'InvoiceNo' => $invoice_no,
 		];
 
-		if (!class_exists('SoapClient')) {
-			return 'SoapClient class not found';
-		}
-
-		$client = new \SoapClient( $this->api_url . '/PayNowEInvoice.asmx?wsdl', $options );
-
-		$soap_result = $client->__soapCall( 'CancelInvoice_I', [ 'parameters' => $params ] );
+		$soap_result = $this->pn_soap_post( 'CancelInvoice_I', $params );
 
 		/** @var string $result 成功:S 失敗:F_  EX: S | F_電子發票(開立/作廢)失敗:資料庫存取失敗 */
 		$result = $soap_result->CancelInvoice_IResult; // phpcs:ignore
@@ -803,30 +827,12 @@ class Paynow_Einvoice {
 
 	function paynow_get_einvoice_url( $order_id, $invoice_no ) {
 
-		$context_options = [
-			'ssl' => [
-				'verify_peer'       => false,
-				'verify_peer_name'  => false,
-				'allow_self_signed' => true,
-				'crypto_method'     => STREAM_CRYPTO_METHOD_TLS_CLIENT,
-			],
-		];
-		$options         = [
-			'soap_version'   => SOAP_1_2,
-			'exceptions'     => true,
-			'trace'          => 1,
-			'cache_wsdl'     => WSDL_CACHE_NONE,
-			'stream_context' => stream_context_create( $context_options ),
-		];
-
-		$client = new SoapClient( $this->api_url . '/PayNowEInvoice.asmx?wsdl', $options );
-
 		$params = [
 			'mem_cid'   => $this->mem_cid,
 			'InvoiceNo' => $invoice_no,
 		];
 
-		$aryResult = $client->__soapCall( 'Get_InvoiceURL_I', [ 'parameters' => $params ] );
+		$aryResult = $this->pn_soap_post( 'Get_InvoiceURL_I', $params );
 		// $this->pn_write_log( '===>Get_InvoiceURL_I' );
 		// $this->pn_write_log( $aryResult );
 		$invoice_url = ( empty( $aryResult->Get_InvoiceURL_IResult ) ) ? '' : $aryResult->Get_InvoiceURL_IResult;


### PR DESCRIPTION
## Summary

Two independent bug fixes in the PayNow e-invoice module (`includes/paynow-einvoice/`):

1. **Replace `SoapClient` with `wp_remote_post`** — the plugin used PHP's `SoapClient` to talk to `PayNowEInvoice.asmx`. This silently requires the optional `ext-soap` PHP extension. On minimal phpfpm images that omit it, every issuance/cancel/get-URL call hits a Fatal `Undefined constant "SOAP_1_2"` before any HTTP request is sent. A new private helper `pn_soap_post()` hand-builds the SOAP 1.2 envelope and dispatches it via `wp_remote_post`, returning a `stdClass` whose shape matches the original `__soapCall` response so the three call sites change minimally.

2. **Populate `CarrierID_1` / `CarrierID_2` for easycard & cdc carriers** — `issue_einvoice()` only set the carrier ID for `ei_carrier_type_mobile_code`. Orders that selected `ei_carrier_type_easycard_code` (悠遊卡) or `ei_carrier_type_cdc_code` (自然人憑證) were sent to PayNow with the carrier *type* but a blank carrier *ID*, causing `悠遊卡載具明碼空白` / `自然人憑證載具明碼空白` rejections. The customer's value stored in `_paynow_ei_carrier_num` is now read for these two branches too.

## Why both in one PR

They were found while debugging the same production incident (auto-invoice issuance silently failing on a site whose phpfpm image was missing `ext-soap`). Once the SOAP fatal was unblocked, the carrier_id bug surfaced as the next failure mode. Splitting into two commits inside this PR makes the diff easy to review independently.

## Risk assessment

**SOAP replacement**
- All three operations (`UploadInvoice_Patch`, `CancelInvoice_I`, `Get_InvoiceURL_I`) use flat scalar parameters and a single-string return; no WSDL-driven type marshalling is needed.
- Production & sandbox endpoints share the same target namespace (`https://invoice.PayNow.com.tw/`), so one hard-coded namespace is safe for both.
- The original code never catches `SoapFault` anywhere in the plugin, so swapping the exception type to `\Exception` does not change error-handling behaviour.
- `htmlspecialchars(..., ENT_XML1 | ENT_QUOTES, 'UTF-8')` handles the three parameter values safely; `csvStr` is base64+url-encoded so its character set is XML-safe anyway.
- `sslverify => false` matches the previous `verify_peer => false` posture.

**carrier_id fix**
- Pure addition (4 lines). The mobile-code branch is untouched.
- Orders that previously sent empty carrier IDs were already being rejected by PayNow; for those, behaviour is unchanged (still rejected with the same error). For orders that had a valid value in `_paynow_ei_carrier_num`, the value now reaches PayNow and the invoice can be issued.

## Verified end-to-end

Tested against `https://invoice.paynow.com.tw` (production) on a real shop with 45 historically failed orders. After applying both patches, 39 orders were issued cleanly; the remaining 6 needed customer data fixes (invalid phone numbers, mismatched carrier_type vs carrier_num format) — none of which were plugin bugs.

## Test plan

- [ ] Activate plugin on a site **without** `ext-soap` enabled in PHP; confirm `UploadInvoice_Patch` succeeds.
- [ ] On a site **with** `ext-soap` enabled, confirm no regression (issue + cancel + get URL flows).
- [ ] Place an order using each carrier type — mobile_code, easycard_code, cdc_code — and verify invoice issues with carrier ID populated.
- [ ] Place an order using donate / b2b / b2c with no carrier; confirm unchanged behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)