### PR TITLE
fix(hpos): PayNow transaction_id 與 RY 物流 shipping_address_1 改用 setter 才能寫入（rebase #113）

### DIFF
--- a/includes/paynow-payment/includes/gateways/class-paynow-payment-response.php
+++ b/includes/paynow-payment/includes/gateways/class-paynow-payment-response.php
@@ -203,7 +203,9 @@ class PayNow_Payment_Response {
 
 			$order->update_meta_data( '_paynow_tran_id', $buysafe_no );
 			$order->update_meta_data( '_paynow_tran_status', $tran_status );
-			$order->update_meta_data( '_transaction_id', $buysafe_no );
+			// HPOS 下 `_transaction_id` 是 wc_orders.transaction_id 欄位，
+			// 透過 update_meta_data 寫入會被靜默丟棄，必須使用 setter。
+			$order->set_transaction_id( $buysafe_no );
 
 			// 虛擬帳號 virtual account pay type = 03.
 			if ( PayNow_Pay_Type::VIRTUAL_ACCOUNT === $pay_type ) {

--- a/includes/ry-woocommerce-tools/woocommerce/shipping/ry-base.php
+++ b/includes/ry-woocommerce-tools/woocommerce/shipping/ry-base.php
@@ -185,14 +185,14 @@ final class RY_Shipping {
 								$order->update_meta_data( '_shipping_cvs_store_telephone', wc_clean( wp_unslash( $_POST['_shipping_cvs_store_telephone'] ) ) );
 								$order->save_meta_data();
 
-								// HPOS 相容：使用物件方法操作 meta。
-								// 改用 save_meta_data() 而非 save()，避免再次觸發 woocommerce_update_order 造成遞迴。
-								// 因為這裡僅更新 meta（_shipping_address_1 與 _shipping_address_index 均屬訂單 meta），
-								// 不涉及訂單核心欄位，save_meta_data() 已足以在 HPOS 與傳統儲存模式下正確寫入。
+								// HPOS：_shipping_address_1 對應 wc_order_addresses.address_1，屬訂單核心欄位，
+								// 在 HPOS 下透過 update_meta_data 寫入會被靜默丟棄，必須改用 setter；_shipping_address_index 才是 meta。
+								// setter 更新的是物件 prop，需 $order->save() 才會持久化（save_meta_data() 只寫 meta、不寫核心欄位）。
+								// 遞迴由本函式頂端的 $processing 守衛阻擋，此處呼叫 save() 安全。
 								$shipping_address = $order->get_address( 'shipping' );
-								$order->update_meta_data( '_shipping_address_1', wc_clean( wp_unslash( $_POST['_shipping_cvs_store_address'] ) ) );
+								$order->set_shipping_address_1( wc_clean( wp_unslash( $_POST['_shipping_cvs_store_address'] ) ) );
 								$order->update_meta_data( '_shipping_address_index', implode( ' ', $shipping_address ) );
-								$order->save_meta_data();
+								$order->save();
 							}
 						}
 					}


### PR DESCRIPTION
Closes #112. Supersedes #113。

## 摘要

本 PR 是 #113 rebase 到最新 `master` 並解完衝突的版本。修正 2 處對核心欄位用 `update_meta_data()` 寫入、HPOS 下會被靜默丟棄的 bug：

1. **PayNow 付款**：IPN 回應時 `_transaction_id` 寫不進去（影響退款、對帳）
2. **RY 物流**：選 CVS 取貨點後 `_shipping_address_1` 寫不進去（shipping address 不更新）

## 為什麼需要重開（#113 的問題）

#113 從舊 `master` 分出，之後 `master` 落地 `27cedf7 fix(shipping): 防止 save_order_update 函式遞迴觸發`，動到 `ry-base.php` 同幾行，導致 #113 衝突（`CONFLICTING`）。

`27cedf7` 在修遞迴時，把該區塊的 `$order->save()` 降成 `$order->save_meta_data()`，並加註解宣稱 `_shipping_address_1` 「屬訂單 meta、不涉及核心欄位」。**此判斷有誤**——HPOS 下 `_shipping_address_1` 對應 `wc_order_addresses.address_1`，是核心欄位，`update_meta_data` + `save_meta_data()` 會被靜默丟棄。

若把 #113 的 `set_shipping_address_1()` 直接配上 `master` 現有的 `save_meta_data()`，setter 更新的 prop 不會被持久化（`save_meta_data()` 只寫 meta、不寫核心欄位），修正等於空包彈。

## 衝突解析（正解）

`ry-base.php` 收斂為三要件並存：

- `set_shipping_address_1()`（核心欄位必須用 setter）
- `$order->save()`（setter prop 需 full save 才持久化，非 `save_meta_data()`）
- 保留 `27cedf7` 的遞迴守衛（函式頂端 `$processing` + `finally` unset）—— `save()` 觸發的 `woocommerce_update_order` 重入會被守衛擋下，`save()` 在此安全

並移除 `27cedf7` 中事實錯誤的註解，換成正確說明。

PayNow 那一處（`set_transaction_id()`）無衝突，與 #113 相同；其後 `$order->save()` 在成功/暫止兩分支皆會呼叫，prop 會持久化。

## 變動

```diff
 // includes/paynow-payment/includes/gateways/class-paynow-payment-response.php
-$order->update_meta_data( '_transaction_id', $buysafe_no );
+$order->set_transaction_id( $buysafe_no );
```

```diff
 // includes/ry-woocommerce-tools/woocommerce/shipping/ry-base.php
 $shipping_address = $order->get_address( 'shipping' );
-$order->update_meta_data( '_shipping_address_1', wc_clean( wp_unslash( $_POST['_shipping_cvs_store_address'] ) ) );
+$order->set_shipping_address_1( wc_clean( wp_unslash( $_POST['_shipping_cvs_store_address'] ) ) );
 $order->update_meta_data( '_shipping_address_index', implode( ' ', $shipping_address ) );
-$order->save_meta_data();
+$order->save();
```

## 驗證

- `php -l` 兩檔皆通過
- 無殘留衝突標記、`git diff --check` 乾淨、brace 結構平衡

## 測試方法（需 HPOS 站台）

- PayNow：HPOS + 啟用 PayNow → 完成付款 → 收 IPN → 看 `wc_orders.transaction_id` / `$order->get_transaction_id()` 有值
- RY 物流：HPOS + 啟用 RY CVS 取貨 → 選店點 → 看 `wc_order_addresses` shipping row 的 `address_1` 變成店點地址

> 衝突解析帶 `save()` vs `save_meta_data()` 的實際風險，光讀 code 抓不到，merge 前務必在 HPOS 站台實測這 2 條路徑。

## 已知 minor（未在本 PR 處理）

`_shipping_address_index` 由 setter 之前抓的 `$shipping_address` 快照組成，index 不含新店點 address_1。此為 #113 base 與 `master` 皆有的 pre-existing 行為，非本 PR 引入，留待後續處理。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)