### PR TITLE
fix(payuni): 信用卡v3 開 3D 驗證時導向 PayUni 3D OTP 頁（修正卡在「尚未付款」）

### DIFF
--- a/includes/payuni/src/gateways/CreditV3.php
+++ b/includes/payuni/src/gateways/CreditV3.php
@@ -383,6 +383,18 @@ class CreditV3 extends AbstractGateway
 				$order->save();
 			}
 
+			// 3D 驗證流程：merchant_trade 成功時會回傳 3D 驗證頁網址（$trade_result['URL']），
+			// 必須將顧客導向該頁完成 OTP，否則 3D session 不會完成，訂單會一直停在「等待付款」，
+			// 約 15 分鐘後 PayUni webhook 才回授權失敗（未取得結果 / Transaction not exists）。
+			if (! empty($trade_result['URL'])) {
+				return [
+					'result'   => 'success',
+					'redirect' => $trade_result['URL'],
+					'order_id' => $order_id,
+				];
+			}
+
+			// 無 3D（已直接授權，有 TradeNo）或回應未帶導向網址時，導回訂單完成頁
 			return [
 				'result'   => 'success',
 				'redirect' => $order->get_checkout_order_received_url(),


### PR DESCRIPTION
## 問題

啟用「信用卡v3」gateway（`payuni-credit-v3`，`PAYUNI\Gateways\CreditV3`）並開啟 3D 驗證（`payuni_3d_auth = yes`）時，顧客填完信用卡 → **直接跳到「尚未付款 / 訂單完成」頁，不會進入 3D OTP 驗證**。約 14~15 分鐘後 PayUni webhook 才回授權失敗。

正式環境實測（icba.club / MerID `NPPA90136979`），8 筆測試單全部同一模式，每張訂單都有註記「3D 驗證已建立，等待 webhook 回傳交易結果」，webhook 回：

- `CREDIT05002 授權失敗`，ResCode `ZZ`（未取得結果）/ `-323`（Transaction not exists）/ `-324`（訂單未完成未收到發卡行回覆）

排除：`token_get`、`merchant_trade` API 皆 `Status: SUCCESS`，IP 白名單 / HashKey / 憑證 / 3D 設定皆正常 —— 純粹是拿到 3D 網址後沒導頁。

## 根因

`CreditV3::process_payment()`（`includes/payuni/src/gateways/CreditV3.php`）server 端呼叫 `merchant_trade` 後，`process_notify()` 已解密出 3D 驗證頁網址：

```json
{"Status":"SUCCESS","Message":"建立幕後3D成功","URL":"https://api.payuni.com.tw/api/credit/api_3d/...?traceId=..."}
```

但 3D 流程（回應無 `TradeNo`）只加了一條訂單註記，接著**不論如何都回傳 `$order->get_checkout_order_received_url()`**，把 `$trade_result['URL']` 整個丟掉。瀏覽器因此被導到訂單完成頁，3D session 無人造訪完成 → PayUni timeout → webhook 授權失敗。

對照：舊版非 v3 gateway（`Credit.php` → `Request::build_request`）本來就有把 `api_3d` URL 當作 redirect 回傳，v3 改寫時遺漏了這步。

## 修正

3D 流程改為將顧客導向 `$trade_result['URL']` 完成 OTP；完成後由既有 webhook（`woocommerce_api_payuni_notify` → `Bootstrap::handle_notify`）更新訂單狀態。無 3D（直接授權、有 `TradeNo`）或回應未帶導向網址時，維持原本導回訂單完成頁的行為。

```php
if (! empty($trade_result['URL'])) {
    return [
        'result'   => 'success',
        'redirect' => $trade_result['URL'],
        'order_id' => $order_id,
    ];
}
```

只在「3D 流程且有導向網址」時改變行為，對直接授權與其他流程零影響。`php -l` 通過。

## 測試方式

開啟信用卡v3 + 3D 驗證，下單填卡 → 應跳轉到銀行 3D OTP 頁，完成驗證後訂單轉為已付款（而非停在「尚未付款」）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)