### PR TITLE
feat(ecpay): 後台退款串接綠界 DoAction API

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -76,6 +76,8 @@ woomp/
 ### 金流閘道模式
 所有金流閘道繼承 `WC_Payment_Gateway`（或 `WC_Payment_Gateway_CC`）。PayUni v1 使用 `PAYUNI\Gateways\AbstractGateway`。PayUni v3 使用 PSR-4 命名空間 `J7\Payuni\`，搭配 DTO/Infrastructure 分層架構。
 
+ECPay（綠界）閘道基底 `RY_ECPay_Gateway_Base` 已實作後台退款（`supports[] = 'refunds'` + `process_refund()`）：信用卡類（`payment_type = Credit`）退款會同步呼叫綠界 `CreditDetail/DoAction` API 退刷（前置以 `QueryTradeInfo` 驗證交易狀態，未關帳且全額退款時降級為放棄授權 `Action=N`）；非信用卡（ATM／超商代碼／超商條碼／WebATM）無線上退款 API，回傳 `WP_Error` 引導商家至綠界後台人工退款。
+
 ### HPOS 相容性
 
 WooCommerce 7.1 起引入高效能訂單儲存（HPOS），訂單資料改存於專屬資料表而非 `wp_postmeta`。本外掛已完整宣告並實作 HPOS 相容。

--- a/.claude/rules/wordpress-php.md
+++ b/.claude/rules/wordpress-php.md
@@ -95,6 +95,8 @@ class CreditV3 extends AbstractGateway {
 
 金流閘道關鍵方法：`init_form_fields()`、`process_payment()`、`process_refund()`、`payment_fields()`。
 
+當單一基底類別涵蓋多種付款方式時（如 ECPay `RY_ECPay_Gateway_Base` 同時涵蓋信用卡／ATM／超商代碼／超商條碼／WebATM），`process_refund()` 可依 `payment_type` 等屬性分流：可線上退款的類型轉呼叫廠商 API，其餘類型直接回傳 `WP_Error`（繁中訊息說明並非系統故障、引導商家至廠商後台人工退款），避免整個閘道一律回傳失敗或誤判為錯誤。範例：`includes/ry-woocommerce-tools/woocommerce/gateways/ecpay/includes/ecpay-gateway-base.php`。
+
 ## 物流方式模式
 
 物流方式繼承 `WC_Shipping_Method`，透過 `woocommerce_shipping_methods` 過濾器註冊：

--- a/includes/ry-woocommerce-tools/woocommerce/gateways/ecpay/includes/ecpay-gateway-api.php
+++ b/includes/ry-woocommerce-tools/woocommerce/gateways/ecpay/includes/ecpay-gateway-api.php
@@ -5,11 +5,14 @@ class RY_ECPay_Gateway_Api extends RY_ECPay {
 		'checkout' => 'https://payment-stage.ecpay.com.tw/Cashier/AioCheckOut/V5',
 		'query'    => 'https://payment-stage.ecpay.com.tw/Cashier/QueryTradeInfo/V5',
 		'sptoken'  => 'https://payment-stage.ecpay.com.tw/SP/CreateTrade',
+		// 注意：綠界 Stage 測試環境不支援 DoAction（無法真實授權），僅正式環境可實際退刷。
+		'refund'   => 'https://payment-stage.ecpay.com.tw/CreditDetail/DoAction',
 	];
 	public static $api_url      = [
 		'checkout' => 'https://payment.ecpay.com.tw/Cashier/AioCheckOut/V5',
 		'query'    => 'https://payment.ecpay.com.tw/Cashier/QueryTradeInfo/V5',
 		'sptoken'  => 'https://payment.ecpay.com.tw/SP/CreateTrade',
+		'refund'   => 'https://payment.ecpay.com.tw/CreditDetail/DoAction',
 	];
 
 	public static function checkout_form( $order, $gateway ) {
@@ -159,5 +162,238 @@ $("#ry-ecpay-form").submit();'
 		}
 		$item_name = rtrim( $item_name, '#' );
 		return $item_name;
+	}
+
+	/**
+	 * 取得指定 API 端點網址（依測試／正式環境切換）
+	 *
+	 * @param string $key 端點鍵名（checkout／query／sptoken／refund）。
+	 * @return string 端點網址。
+	 */
+	protected static function get_api_url( $key ) {
+		if ( 'yes' === RY_WT::get_option( 'ecpay_gateway_testmode', 'yes' ) ) {
+			return self::$api_test_url[ $key ];
+		}
+		return self::$api_url[ $key ];
+	}
+
+	/**
+	 * 綠界後台信用卡退款編排（方案 B′）
+	 *
+	 * 流程：
+	 * 1. 前置檢查綠界交易編號（TradeNo）存在、分期強制全額退款。
+	 * 2. QueryTradeInfo 前置驗證訂單付款狀態，失敗即中止（不送出 DoAction）。
+	 * 3. 送出 DoAction Action=R 退刷；RtnCode=1 即成功。
+	 * 4. 若綠界回覆「尚未關帳」且為全額退款，降級送出 Action=N 取消授權。
+	 * 5. 其他失敗一律回 WP_Error（fail-closed，不標記已退款）。
+	 *
+	 * @param WC_Order           $order   訂單物件。
+	 * @param float|null         $amount  退款金額（null 表示全額）。
+	 * @param string             $reason  退款原因。
+	 * @param WC_Payment_Gateway $gateway 觸發退款的金流閘道。
+	 * @return bool|WP_Error 成功回傳 true；失敗回傳 WP_Error。
+	 */
+	public static function process_credit_refund( $order, $amount, $reason, $gateway ) {
+		$trade_no = $order->get_transaction_id();
+		if ( empty( $trade_no ) ) {
+			return new WP_Error(
+				'ry_ecpay_refund_no_trade_no',
+				__( '查無綠界交易編號，無法透過綠界退款。請確認訂單付款狀態，或登入綠界廠商後台處理。', 'ry-woocommerce-tools' )
+			);
+		}
+
+		// $amount 為 null 時（WooCommerce process_refund 慣例）視為全額退款。
+		if ( null === $amount ) {
+			$amount = $order->get_total();
+		}
+
+		// 金額雙邊採一致取整（對齊結帳送綠界的 (int) ceil 交易金額），避免含小數訂單把全額退款誤判為部分退款。
+		$refund_amount = (int) ceil( (float) $amount );
+		$order_total   = (int) ceil( (float) $order->get_total() );
+
+		// 縱深防護：退款金額須大於 0 且不超過訂單金額（WooCommerce 核心已驗可退餘額，此處為本層再驗，防止超額退款）。
+		if ( $refund_amount <= 0 || $refund_amount > $order_total ) {
+			return new WP_Error(
+				'ry_ecpay_refund_amount_invalid',
+				__( '退款金額不正確，必須大於 0 且不超過訂單金額。', 'ry-woocommerce-tools' )
+			);
+		}
+
+		$is_full = ( $refund_amount >= $order_total );
+
+		// 信用卡分期／紅利僅支援全額退款，於呼叫綠界 API 前攔截部分退款。
+		if ( false !== strpos( $gateway->id, 'installment' ) && ! $is_full ) {
+			return new WP_Error(
+				'ry_ecpay_refund_installment_full_only',
+				__( '信用卡分期付款僅支援全額退款，無法部分退款。請改為全額退款。', 'ry-woocommerce-tools' )
+			);
+		}
+
+		// 前置驗證：查詢綠界交易狀態，失敗即中止。
+		$query = self::query_trade_info( $order );
+		if ( is_wp_error( $query ) ) {
+			return $query;
+		}
+
+		// 主路徑：Action=R 退刷。
+		$result = self::do_credit_action( $order, 'R', $refund_amount );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		if ( '1' === (string) ( $result['RtnCode'] ?? '' ) ) {
+			$order->add_order_note(
+				sprintf(
+					/* translators: 1: 退款金額 2: 綠界回應訊息 */
+					__( '綠界退款成功（退刷 R，金額 %1$s）：%2$s', 'ry-woocommerce-tools' ),
+					$refund_amount,
+					$result['RtnMsg'] ?? ''
+				)
+			);
+			RY_ECPay_Gateway::log( 'Refund(R) success for #' . $order->get_order_number() . ' amount=' . $refund_amount );
+			return true;
+		}
+
+		// 綠界回覆尚未關帳且為全額退款 → 降級 Action=N 取消授權。
+		$rtn_msg = (string) ( $result['RtnMsg'] ?? '' );
+		if ( false !== strpos( $rtn_msg, '未關帳' ) && $is_full ) {
+			$result_n = self::do_credit_action( $order, 'N', $refund_amount );
+			if ( is_wp_error( $result_n ) ) {
+				return $result_n;
+			}
+
+			if ( '1' === (string) ( $result_n['RtnCode'] ?? '' ) ) {
+				$order->add_order_note(
+					sprintf(
+						/* translators: 1: 退款金額 2: 綠界回應訊息 */
+						__( '綠界退款成功（尚未關帳，改以放棄授權 N，金額 %1$s）：%2$s', 'ry-woocommerce-tools' ),
+						$refund_amount,
+						$result_n['RtnMsg'] ?? ''
+					)
+				);
+				RY_ECPay_Gateway::log( 'Refund(N) success for #' . $order->get_order_number() . ' amount=' . $refund_amount );
+				return true;
+			}
+
+			return new WP_Error(
+				'ry_ecpay_refund_action_n_failed',
+				sprintf(
+					/* translators: %s 綠界回應訊息 */
+					__( '綠界退款失敗（放棄授權 N）：%s', 'ry-woocommerce-tools' ),
+					$result_n['RtnMsg'] ?? ''
+				)
+			);
+		}
+
+		return new WP_Error(
+			'ry_ecpay_refund_doaction_rejected',
+			sprintf(
+				/* translators: %s 綠界回應訊息 */
+				__( '綠界退款失敗：%s', 'ry-woocommerce-tools' ),
+				$rtn_msg
+			)
+		);
+	}
+
+	/**
+	 * 呼叫綠界 QueryTradeInfo 查詢並驗證交易狀態（退款前置驗證）
+	 *
+	 * @param WC_Order $order 訂單物件。
+	 * @return array|WP_Error 成功回傳解析後的回應陣列；失敗回傳 WP_Error。
+	 */
+	protected static function query_trade_info( $order ) {
+		list( $merchant_id, $hash_key, $hash_iv ) = RY_ECPay_Gateway::get_ecpay_api_info();
+
+		$args = [
+			'MerchantID'      => $merchant_id,
+			'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+			'TimeStamp'       => time(),
+		];
+		$args = self::add_check_value( $args, $hash_key, $hash_iv, 'sha256' );
+
+		$response = self::link_server( self::get_api_url( 'query' ), $args );
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'ry_ecpay_refund_query_failed',
+				__( '無法連線綠界查詢交易狀態，退款已中止。', 'ry-woocommerce-tools' ) . ' ' . $response->get_error_message()
+			);
+		}
+
+		parse_str( wp_remote_retrieve_body( $response ), $result );
+
+		if ( ! self::verify_response_check_value( $result, $hash_key, $hash_iv ) ) {
+			return new WP_Error( 'ry_ecpay_refund_query_checkmac_failed', __( '綠界查詢回應驗證失敗（CheckMacValue 不符），退款已中止。', 'ry-woocommerce-tools' ) );
+		}
+
+		if ( '1' !== (string) ( $result['TradeStatus'] ?? '' ) ) {
+			return new WP_Error( 'ry_ecpay_refund_trade_not_paid', __( '訂單尚未完成付款，無法退款。', 'ry-woocommerce-tools' ) );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * 呼叫綠界 CreditDetail/DoAction 執行信用卡請退款動作
+	 *
+	 * @param WC_Order $order  訂單物件。
+	 * @param string   $action 動作代碼（C 關帳／R 退刷／E 取消關帳／N 放棄）。
+	 * @param int      $amount 金額。
+	 * @return array|WP_Error 成功回傳解析後的回應陣列；失敗回傳 WP_Error。
+	 */
+	protected static function do_credit_action( $order, $action, $amount ) {
+		list( $merchant_id, $hash_key, $hash_iv ) = RY_ECPay_Gateway::get_ecpay_api_info();
+
+		$merchant_trade_no = $order->get_meta( '_ecpay_MerchantTradeNo' );
+		$trade_no          = $order->get_transaction_id();
+
+		$args = [
+			'MerchantID'      => $merchant_id,
+			'MerchantTradeNo' => $merchant_trade_no,
+			'TradeNo'         => $trade_no,
+			'Action'          => $action,
+			'TotalAmount'     => (int) $amount,
+		];
+		$args = self::add_check_value( $args, $hash_key, $hash_iv, 'sha256' );
+
+		$response = self::link_server( self::get_api_url( 'refund' ), $args );
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'ry_ecpay_refund_doaction_failed',
+				__( '無法連線綠界退款服務，退款已中止。', 'ry-woocommerce-tools' ) . ' ' . $response->get_error_message()
+			);
+		}
+
+		parse_str( wp_remote_retrieve_body( $response ), $result );
+
+		// 綠界 CreditDetail/DoAction 回應僅含 MerchantID／MerchantTradeNo／TradeNo／RtnCode／RtnMsg，
+		// 不含 CheckMacValue（與 QueryTradeInfo 不同，故此路徑「不」驗章）。改以「回應綁定原請求」防偽：
+		// 回應真實性由 TLS 通道保護（link_server 未關 sslverify），並比對回應的 MerchantTradeNo／TradeNo
+		// 與本訂單一致，避免回應被替換或錯配到其他訂單。
+		if ( ! isset( $result['RtnCode'] ) ) {
+			return new WP_Error( 'ry_ecpay_refund_doaction_bad_response', __( '綠界退款回應格式異常，退款已中止。', 'ry-woocommerce-tools' ) );
+		}
+
+		if ( ( $result['MerchantTradeNo'] ?? '' ) !== (string) $merchant_trade_no
+			|| ( $result['TradeNo'] ?? '' ) !== (string) $trade_no ) {
+			return new WP_Error( 'ry_ecpay_refund_doaction_mismatch', __( '綠界退款回應與本訂單不符，退款已中止。', 'ry-woocommerce-tools' ) );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * 驗證綠界回應的 CheckMacValue 是否與依官方演算法重算的結果一致
+	 *
+	 * @param array  $result   解析後的回應陣列。
+	 * @param string $hash_key 綠界 HashKey。
+	 * @param string $hash_iv  綠界 HashIV。
+	 * @return bool 驗證通過回傳 true。
+	 */
+	protected static function verify_response_check_value( $result, $hash_key, $hash_iv ) {
+		if ( ! isset( $result['CheckMacValue'] ) ) {
+			return false;
+		}
+		$expected = self::generate_check_value( $result, $hash_key, $hash_iv, 'sha256' );
+		return hash_equals( $expected, (string) $result['CheckMacValue'] );
 	}
 }

--- a/includes/ry-woocommerce-tools/woocommerce/gateways/ecpay/includes/ecpay-gateway-base.php
+++ b/includes/ry-woocommerce-tools/woocommerce/gateways/ecpay/includes/ecpay-gateway-base.php
@@ -5,11 +5,43 @@ class RY_ECPay_Gateway_Base extends WC_Payment_Gateway {
 	public static $log         = false;
 
 	public function __construct() {
+		// 宣告支援 WooCommerce 後台退款：信用卡走綠界 DoAction API 同步退刷，非信用卡回人工退款指引。
+		$this->supports[] = 'refunds';
+
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
 
 		if ( $this->enabled ) {
 			add_action( 'woocommerce_receipt_' . $this->id, [ $this, 'receipt_page' ] );
 		}
+	}
+
+	/**
+	 * WooCommerce 後台退款進入點
+	 *
+	 * 依付款方式分流：信用卡類（payment_type = Credit）轉呼叫綠界 DoAction 退款 API；
+	 * 非信用卡（ATM／超商代碼／超商條碼／網路 ATM）綠界無線上退款 API，回傳 WP_Error 指引商家人工退款。
+	 * 採 fail-closed：任何不確定或失敗一律回 WP_Error 中止，不標記已退款。
+	 *
+	 * @param int        $order_id 訂單 ID。
+	 * @param float|null $amount   退款金額（null 表示全額）。
+	 * @param string     $reason   退款原因。
+	 * @return bool|WP_Error 成功回傳 true；失敗回傳 WP_Error。
+	 */
+	public function process_refund( $order_id, $amount = null, $reason = '' ) {
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return new WP_Error( 'ry_ecpay_refund_no_order', __( '找不到訂單，無法退款。', 'ry-woocommerce-tools' ) );
+		}
+
+		// 僅信用卡類（payment_type = Credit）支援綠界線上退款 API。
+		if ( 'Credit' !== $this->payment_type ) {
+			return new WP_Error(
+				'ry_ecpay_refund_unsupported_method',
+				__( '此付款方式（ATM／超商代碼／超商條碼／網路 ATM）不支援綠界線上退款 API，並非系統故障。請登入綠界廠商後台手動辦理退款，或聯繫綠界客服。', 'ry-woocommerce-tools' )
+			);
+		}
+
+		return RY_ECPay_Gateway_Api::process_credit_refund( $order, $amount, $reason, $this );
 	}
 
 	public function get_icon() {

--- a/init.php
+++ b/init.php
@@ -5,7 +5,7 @@
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'WOOMP_VERSION', '3.5.12' );
+define( 'WOOMP_VERSION', '3.5.13' );
 define( 'WOOMP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'WOOMP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WOOMP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/specs/ecpay-payment.activity
+++ b/specs/ecpay-payment.activity
@@ -95,3 +95,4 @@ Side Effects:
 Related Features:
   - ecpay-payment.feature
   - ecpay-shipping.activity
+  - ecpay-refund.feature

--- a/specs/ecpay-refund.activity
+++ b/specs/ecpay-refund.activity
@@ -1,0 +1,75 @@
+Activity: 綠界 ECPay 後台退款流程
+Description: 管理員於 WooCommerce 後台對綠界訂單發起退款，信用卡類會同步呼叫綠界 CreditDetail/DoAction API 完成退刷；非信用卡類回傳人工退款指引
+
+Actors:
+  - Admin: 網站管理員（後台操作退款）
+  - WooCommerce: WooCommerce 訂單管理（觸發 process_refund）
+  - ECPay_Gateway_Base: RY_ECPay_Gateway_Base 及其子類別（process_refund 進入點）
+  - ECPay_Gateway_Api: RY_ECPay_Gateway_Api 類別（退款 API 編排）
+  - ECPay_API: 綠界金流 API 伺服器（payment.ecpay.com.tw / payment-stage.ecpay.com.tw）
+
+Triggers:
+  - Admin 在後台訂單頁面點擊「退款」按鈕並輸入退款金額
+
+Flow:
+  1. Admin 在後台發起部分或全額退款
+     → WooCommerce 呼叫 ECPay_Gateway_Base::process_refund($order_id, $amount, $reason)
+
+  2. 驗證訂單與付款方式
+     → Condition: 訂單是否存在
+       No  → 回傳 WP_Error（找不到訂單，無法退款）
+       Yes → 檢查 payment_type
+     → Condition: payment_type 是否為 'Credit'
+       No（ATM／CVS／BARCODE／WebATM）→ 回傳 WP_Error，訊息指引「請登入綠界廠商後台手動辦理退款，或聯繫綠界客服」（非系統故障），流程結束
+       Yes → 轉呼叫 ECPay_Gateway_Api::process_credit_refund($order, $amount, $reason, $gateway)
+
+  3. 信用卡分期全額限制檢查
+     → Condition: gateway id 是否包含 'installment' 且退款金額 < 訂單總額
+       Yes → 回傳 WP_Error「信用卡分期付款僅支援全額退款，無法部分退款」，不呼叫任何 API
+       No  → 繼續下一步
+
+  4. 前置驗證：ECPay_Gateway_Api::query_trade_info($order)
+     → 組裝 MerchantID、MerchantTradeNo（讀取 _ecpay_MerchantTradeNo meta）、TimeStamp
+     → 計算 CheckMacValue（SHA256）
+     → POST 至 ECPay_API（Cashier/QueryTradeInfo/V5，依測試/正式環境切換 get_api_url）
+     → Condition: 連線是否成功
+       No → 回傳 WP_Error，中止（不送出 DoAction）
+     → Condition: 回應 CheckMacValue 是否驗證通過
+       No → 回傳 WP_Error，中止
+     → Condition: TradeStatus 是否為 '1'
+       No → 回傳 WP_Error「訂單尚未完成付款，無法退款」，中止
+       Yes → 繼續下一步
+
+  5. 主路徑：ECPay_Gateway_Api::do_credit_action($order, 'R', $amount)
+     → 組裝 MerchantID、MerchantTradeNo、TradeNo（get_transaction_id）、Action=R、TotalAmount
+     → 計算請求 CheckMacValue（SHA256，供綠界驗證入站請求）
+     → POST 至 ECPay_API（CreditDetail/DoAction；Stage 測試環境不支援真實授權）
+     → Condition: 連線是否成功
+       No → 回傳 WP_Error，中止
+     → Condition: 回應是否含 RtnCode，且回應 MerchantTradeNo／TradeNo 是否與本訂單相符
+       （綠界 DoAction 回應依官方規格 2885.md 不含 CheckMacValue，故此路徑不驗章；改以綁定原訂單防偽，回應真實性由 TLS 保護）
+       No → 回傳 WP_Error，中止
+     → Condition: RtnCode 是否為 '1'
+       Yes → 訂單備註記錄「綠界退款成功（退刷 R，金額 X）」→ WC Logger 記錄 → return true
+       No  → 進入步驟 6
+
+  6. 降級判斷（僅主路徑失敗時執行）
+     → Condition: RtnMsg 是否包含「未關帳」且為全額退款
+       No  → 回傳 WP_Error「綠界退款失敗：{RtnMsg}」，流程結束
+       Yes → 呼叫 do_credit_action($order, 'N', $amount)（放棄授權，同步驟 5 的請求/驗證流程）
+         → Condition: RtnCode 是否為 '1'
+           Yes → 訂單備註記錄「綠界退款成功（尚未關帳，改以放棄授權 N，金額 X）」→ WC Logger 記錄 → return true
+           No  → 回傳 WP_Error「綠界退款失敗（放棄授權 N）：{RtnMsg}」
+
+Side Effects:
+  - 成功退款時於訂單備註記錄「綠界退款成功」與實際採用的動作（R 退刷 或 降級 N 放棄授權）
+  - 所有送出/失敗紀錄可透過 RY_ECPay_Gateway::log()（WC Logger source: ry_ecpay_gateway）查看
+  - 失敗一律回傳 WP_Error、不修改訂單狀態、不標記已退款（fail-closed：任何查詢/API 失敗、QueryTradeInfo 回應 CheckMacValue 不符、或 DoAction 回應綁定不符皆中止）
+  - 非信用卡付款方式（ATM／CVS／BARCODE／WebATM）完全不觸發任何對外 API 呼叫
+  - DoAction 在綠界 Stage 測試環境不支援真實授權，僅正式環境可實際退刷
+
+Related Features:
+  - ecpay-refund.feature
+  - ecpay-payment.feature
+  - ecpay-payment.activity
+  - payuni-refund.feature（同類「查詢後決定退款/取消」退款模式的既有實作參考）

--- a/specs/ecpay-refund.feature
+++ b/specs/ecpay-refund.feature
@@ -1,0 +1,127 @@
+Feature: 綠界 ECPay 後台退款
+  As a 管理員
+  I want 在 WooCommerce 後台對綠界訂單發起退款時，信用卡類自動同步呼叫綠界退款 API
+  So that 不需再登入綠界後台手動退刷，也不會誤把無退款 API 的付款方式當成系統故障
+
+  Background:
+    Given 網站已啟用綠界金流（RY_WT_enabled_ecpay_gateway = yes）
+    And 綠界金流已設定 MerchantID、HashKey、HashIV（測試模式使用預設值 3002599）
+    And 訂單已使用某一 ECPay 閘道完成付款，訂單 meta 有 _ecpay_MerchantTradeNo
+    And 所有 ECPay 閘道（RY_ECPay_Gateway_Base 子類別）皆宣告 supports[] = 'refunds'
+
+  Rule: 信用卡退款 — 主路徑（Action=R 退刷）
+
+    Scenario: 信用卡全額退款成功
+      Given 訂單使用 ry_ecpay_credit 付款，總金額 1000 元，且已有綠界 TradeNo
+      When 管理員在後台發起 1000 元退款
+      Then 系統先呼叫 QueryTradeInfo 驗證交易狀態
+      And 系統呼叫 CreditDetail/DoAction，Action=R，TotalAmount=1000
+      And 綠界回傳 RtnCode=1
+      And 訂單備註記錄「綠界退款成功（退刷 R，金額 1000）」
+      And process_refund 回傳 true
+
+    Scenario: 信用卡部分退款成功
+      Given 訂單總金額 1000 元
+      When 管理員發起 300 元部分退款
+      Then DoAction 送出的 TotalAmount 應為 300（而非訂單全額）
+      And process_refund 回傳 true
+
+  Rule: 信用卡退款 — 未關帳降級（Action=N 放棄授權）
+
+    Scenario: 交易尚未關帳且為全額退款時降級為放棄授權
+      Given 訂單總金額 1000 元，管理員發起全額退款
+      When 第一次 DoAction（Action=R）回傳 RtnMsg 包含「未關帳」
+      Then 系統改送第二次 DoAction，Action=N
+      And 第二次回傳 RtnCode=1 時，訂單備註記錄「尚未關帳，改以放棄授權 N」
+      And process_refund 回傳 true
+
+    Scenario: 未關帳但非全額退款時不降級
+      Given 管理員發起未達訂單總額的部分退款
+      When DoAction（Action=R）回傳 RtnMsg 包含「未關帳」
+      Then process_refund 回傳 WP_Error，訊息包含綠界回傳的 RtnMsg
+      And 不觸發 Action=N 降級重試
+
+  Rule: 信用卡分期限制
+
+    Scenario: 分期付款僅支援全額退款
+      Given 訂單使用信用卡分期閘道（gateway id 包含 installment）
+      When 管理員發起未達訂單總額的部分退款
+      Then process_refund 回傳 WP_Error「信用卡分期付款僅支援全額退款，無法部分退款」
+      And 不呼叫任何綠界 API
+
+  Rule: 非信用卡付款方式 — 人工退款指引
+
+    Scenario Outline: 非信用卡閘道退款回傳人工退款指引
+      Given 訂單使用 <閘道類別> 付款（payment_type = <付款類型>）
+      When 管理員在後台發起退款
+      Then process_refund 回傳 WP_Error，訊息包含「請登入綠界廠商後台」
+      And 不呼叫任何綠界 API
+
+      Examples:
+        | 閘道類別                 | 付款類型 |
+        | RY_ECPay_Gateway_Atm     | ATM      |
+        | RY_ECPay_Gateway_Cvc     | CVS      |
+        | RY_ECPay_Gateway_Barcode | BARCODE  |
+        | RY_ECPay_Gateway_Webatm  | WebATM   |
+
+  Rule: 退款前置驗證（fail-closed）
+
+    Scenario: 找不到訂單中止退款
+      Given 傳入的 order_id 查無對應訂單
+      When 管理員發起退款
+      Then process_refund 回傳 WP_Error「找不到訂單，無法退款」
+
+    Scenario: 查無綠界交易編號中止退款
+      Given 訂單尚未完成付款（transaction_id 為空）
+      When 管理員發起退款
+      Then process_refund 回傳 WP_Error「查無綠界交易編號，無法透過綠界退款」
+      And 不呼叫任何綠界 API
+
+    Scenario: QueryTradeInfo 連線失敗中止退款
+      Given 呼叫綠界 QueryTradeInfo 時網路連線失敗
+      When 管理員發起退款
+      Then process_refund 回傳 WP_Error
+      And 僅嘗試 QueryTradeInfo 一次，不送出 DoAction 請求
+
+    Scenario: 訂單尚未付款完成中止退款
+      Given QueryTradeInfo 回傳 TradeStatus 非 1
+      When 管理員發起退款
+      Then process_refund 回傳 WP_Error「訂單尚未完成付款，無法退款」
+      And 不送出 DoAction 請求
+
+    Scenario: DoAction 失敗且非「未關帳」原因
+      Given DoAction 回傳 RtnCode 非 1 且 RtnMsg 不包含「未關帳」
+      When 管理員發起退款
+      Then process_refund 回傳 WP_Error，訊息包含綠界回傳的 RtnMsg
+      And 不觸發 Action=N 降級重試
+
+  Rule: 安全驗證
+
+    Scenario: DoAction 請求的 CheckMacValue 正確性
+      Given 系統送出 CreditDetail/DoAction 請求
+      Then 請求所帶的 CheckMacValue 應與依綠界官方演算法（SHA256）獨立重算的結果一致
+
+    Scenario: QueryTradeInfo 回應 CheckMacValue 驗證失敗中止流程
+      Given QueryTradeInfo 回應的 CheckMacValue 與重算結果不符
+      When 系統以 hash_equals 驗證回應（verify_response_check_value）
+      Then process_refund 回傳 WP_Error，流程中止且不標記已退款
+
+    Scenario Outline: DoAction 回應綁定防偽（回應不含 CheckMacValue）
+      Given 綠界 CreditDetail/DoAction 回應依官方規格（2885.md）不含 CheckMacValue
+      And 回應的 <欄位> 與本訂單不符
+      When 系統驗證 DoAction 回應（改以 MerchantTradeNo／TradeNo 綁定原訂單，回應真實性由 TLS 保護）
+      Then process_refund 回傳 WP_Error，流程中止且不標記已退款
+
+      Examples:
+        | 欄位            |
+        | MerchantTradeNo |
+        | TradeNo         |
+
+  Rule: 退款相關 API 端點一覽
+
+    Scenario: API 端點對應表
+      Then 綠界退款相關 API 端點如下：
+        | 操作           | 端點                      | 說明                               |
+        | 前置查詢交易   | Cashier/QueryTradeInfo/V5 | 驗證 TradeStatus=1 才允許退款       |
+        | 退刷/放棄授權  | CreditDetail/DoAction     | Action=R 退刷；未關帳降級 Action=N  |
+      And 測試（Stage）環境不支援 DoAction 真實授權，僅正式環境可實際退刷

--- a/tests/phpunit/integration/EcpayRefundTest.php
+++ b/tests/phpunit/integration/EcpayRefundTest.php
@@ -1,0 +1,852 @@
+<?php
+/**
+ * 綠界 ECPay 後台退款 API 同步串接整合測試（issue #123）
+ *
+ * 驗證 WooCommerce 後台對綠界信用卡訂單按「退款」時，process_refund()
+ * 會同步呼叫綠界 CreditDetail/DoAction 進行退刷（含 QueryTradeInfo 前置驗證、
+ * 未關帳降級為 Action=N、非信用卡人工指引、CheckMacValue 組裝正確性等情境）。
+ * 全程以 pre_http_request 攔截 wp_remote_post，不觸發任何真實網路請求。
+ *
+ * TDD Red 階段說明：
+ * 本檔測試預期「全數失敗」。原因：
+ * - process_refund() 目前繼承 WC_Payment_Gateway 的預設實作（永遠 return false），
+ *   尚未依 payment_type 分流、尚未呼叫任何綠界 API。
+ * - query_trade_info() / do_credit_action() / process_credit_refund() 三個新方法
+ *   尚未存在於 RY_ECPay_Gateway_Api。
+ * 測試一律透過 gateway 的公開 process_refund() 介面驅動（黑箱），不直接呼叫
+ * query_trade_info() / do_credit_action()。
+ *
+ * @package Woomp\Tests\Integration
+ */
+
+/**
+ * 綠界後台退款測試類別
+ *
+ * 測試案例對照表（issue #123 實作計劃 10 案例）：
+ * | # | 測試方法 |
+ * |---|----------|
+ * | 1 | test_case_01_full_refund_on_credit_gateway_returns_true |
+ * | 2 | test_case_02_partial_refund_sends_matching_total_amount |
+ * | 3 | test_case_03_not_settled_downgrades_to_action_n |
+ * | 4 | test_case_04_non_credit_gateway_returns_wp_error_with_taiwanese_guidance |
+ * | 5 | test_case_05_installment_partial_refund_rejected_without_api_call |
+ * | 6 | test_case_06_query_trade_info_network_failure_aborts_before_do_action |
+ * | 7 | test_case_07_query_trade_info_trade_status_mismatch_returns_wp_error |
+ * | 8 | test_case_08_do_action_non_settlement_failure_returns_wp_error_with_rtn_msg |
+ * | 9 | test_case_09_do_action_check_mac_value_matches_independent_recalculation |
+ * | 10 | test_case_10_missing_transaction_id_returns_wp_error |
+ *
+ * @covers includes/ry-woocommerce-tools/woocommerce/gateways/ecpay/includes/ecpay-gateway-base.php
+ * @covers includes/ry-woocommerce-tools/woocommerce/gateways/ecpay/includes/ecpay-gateway-api.php
+ * @group gateway
+ * @group ecpay
+ * @group refund
+ */
+class EcpayRefundTest extends WP_UnitTestCase {
+
+	/**
+	 * 測試模式綠界商店代號（與 RY_ECPay_Gateway::get_ecpay_api_info() 測試模式回傳值一致）
+	 *
+	 * @var string
+	 */
+	private const TEST_MERCHANT_ID = '3002599';
+
+	/**
+	 * 測試模式綠界 HashKey（與 RY_ECPay_Gateway::get_ecpay_api_info() 測試模式回傳值一致）
+	 *
+	 * @var string
+	 */
+	private const TEST_HASH_KEY = 'spPjZn66i0OhqJsQ';
+
+	/**
+	 * 測試模式綠界 HashIV（與 RY_ECPay_Gateway::get_ecpay_api_info() 測試模式回傳值一致）
+	 *
+	 * @var string
+	 */
+	private const TEST_HASH_IV = 'hT5OJckN45isQTTs';
+
+	/**
+	 * 本次測試建立的訂單，tearDown 統一刪除
+	 *
+	 * @var WC_Order[]
+	 */
+	private $orders = [];
+
+	/**
+	 * 攔截到送往綠界的請求紀錄
+	 *
+	 * 每筆為 ['url' => string, 'body' => array]。
+	 *
+	 * @var array
+	 */
+	private $sent_requests = [];
+
+	/**
+	 * QueryTradeInfo 假回應佇列（FIFO），為空時退回預設成功回應
+	 *
+	 * @var array
+	 */
+	private $query_responses = [];
+
+	/**
+	 * DoAction 假回應佇列（FIFO），為空時退回預設成功回應
+	 *
+	 * @var array
+	 */
+	private $doaction_responses = [];
+
+	/**
+	 * 設定測試環境
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! class_exists( 'RY_ECPay_Gateway_Credit' ) ) {
+			$this->markTestSkipped( 'ry-woocommerce-tools 綠界模組未載入，跳過退款測試' );
+		}
+
+		$this->orders             = [];
+		$this->sent_requests      = [];
+		$this->query_responses    = [];
+		$this->doaction_responses = [];
+
+		add_filter( 'pre_http_request', [ $this, 'intercept_ecpay_http_request' ], 10, 3 );
+	}
+
+	/**
+	 * 清理測試環境
+	 */
+	public function tearDown(): void {
+		remove_filter( 'pre_http_request', [ $this, 'intercept_ecpay_http_request' ], 10 );
+
+		foreach ( $this->orders as $order ) {
+			if ( $order instanceof WC_Order ) {
+				$order->delete( true );
+			}
+		}
+		$this->orders = [];
+
+		parent::tearDown();
+	}
+
+	// ------------------------------------------------------------------
+	// pre_http_request 攔截器
+	// ------------------------------------------------------------------
+
+	/**
+	 * 攔截送往綠界的 wp_remote_post，記錄送出的請求並回傳假回應
+	 *
+	 * 僅攔截網域包含 ecpay.com.tw 的請求（涵蓋正式站與 Stage 測試站），
+	 * 其餘一律放行，避免影響 WordPress 測試框架本身的其他請求。
+	 *
+	 * @param false|array|WP_Error $preempt     短路回傳值，預設 false。
+	 * @param array                $parsed_args wp_remote_post 的請求參數。
+	 * @param string               $url         請求網址。
+	 * @return false|array|WP_Error
+	 */
+	public function intercept_ecpay_http_request( $preempt, $parsed_args, $url ) {
+		if ( false === strpos( $url, 'ecpay.com.tw' ) ) {
+			return $preempt;
+		}
+
+		$body = [];
+		if ( isset( $parsed_args['body'] ) ) {
+			if ( is_array( $parsed_args['body'] ) ) {
+				$body = $parsed_args['body'];
+			} elseif ( is_string( $parsed_args['body'] ) ) {
+				parse_str( $parsed_args['body'], $body );
+			}
+		}
+
+		$this->sent_requests[] = [
+			'url'  => $url,
+			'body' => $body,
+		];
+
+		if ( false !== strpos( $url, 'QueryTradeInfo' ) ) {
+			if ( ! empty( $this->query_responses ) ) {
+				return array_shift( $this->query_responses );
+			}
+			return $this->build_ecpay_http_response(
+				[
+					'MerchantID'      => self::TEST_MERCHANT_ID,
+					'MerchantTradeNo' => $body['MerchantTradeNo'] ?? 'TESTMTN000000',
+					'TradeNo'         => 'ECTESTTN00001',
+					'TradeAmt'        => '1000',
+					'PaymentType'     => 'Credit_CreditCard',
+					'TradeDate'       => gmdate( 'Y/m/d H:i:s' ),
+					'PaymentDate'     => gmdate( 'Y/m/d H:i:s' ),
+					'TradeStatus'     => '1',
+				]
+			);
+		}
+
+		if ( false !== strpos( $url, 'DoAction' ) ) {
+			if ( ! empty( $this->doaction_responses ) ) {
+				return array_shift( $this->doaction_responses );
+			}
+			// DoAction 回應不含 CheckMacValue（綠界官方規格 2885.md），以 $include_check_mac=false 模擬真實契約。
+			return $this->build_ecpay_http_response(
+				[
+					'MerchantID'      => self::TEST_MERCHANT_ID,
+					'MerchantTradeNo' => $body['MerchantTradeNo'] ?? 'TESTMTN000000',
+					'TradeNo'         => $body['TradeNo'] ?? 'ECTESTTN00001',
+					'RtnCode'         => '1',
+					'RtnMsg'          => 'Succeeded',
+				],
+				false
+			);
+		}
+
+		return $preempt;
+	}
+
+	// ------------------------------------------------------------------
+	// Fixture 建構
+	// ------------------------------------------------------------------
+
+	/**
+	 * 建立一筆已付款的綠界訂單 fixture
+	 *
+	 * @param string      $gateway_id         金流閘道 ID（決定 payment_method）。
+	 * @param float       $total              訂單總金額。
+	 * @param string|null $trade_no           綠界交易編號（TradeNo）。傳入 null 表示
+	 *                                        不呼叫 payment_complete()，模擬查無交易編號的訂單。
+	 * @param string      $merchant_trade_no  商店訂單編號（_ecpay_MerchantTradeNo meta）。
+	 *                                        留空則自動產生。
+	 * @return WC_Order
+	 */
+	private function create_ecpay_order( string $gateway_id, float $total, ?string $trade_no, string $merchant_trade_no = '' ): WC_Order {
+		if ( '' === $merchant_trade_no ) {
+			$merchant_trade_no = 'TESTMTN' . wp_rand( 100000, 999999 );
+		}
+
+		$order = wc_create_order();
+		$order->set_payment_method( $gateway_id );
+		$order->set_total( $total );
+		$order->set_status( 'pending' );
+		$order->update_meta_data( '_ecpay_MerchantTradeNo', $merchant_trade_no );
+		$order->save();
+
+		if ( null !== $trade_no ) {
+			$order->payment_complete( $trade_no );
+		}
+
+		$order           = wc_get_order( $order->get_id() );
+		$this->orders[] = $order;
+
+		return $order;
+	}
+
+	// ------------------------------------------------------------------
+	// CheckMacValue（獨立重算，供斷言比對）
+	// ------------------------------------------------------------------
+
+	/**
+	 * 依綠界官方演算法獨立重算 CheckMacValue
+	 *
+	 * 複製 RY_ECPay::generate_check_value() 的邏輯（ksort + HashKey/HashIV
+	 * 前後包夾 + 特殊 urlencode + 轉小寫 + SHA256 + 轉大寫），使用測試模式
+	 * 憑證，供斷言比對「送出的 CheckMacValue」是否正確。因原方法為
+	 * protected，非同一繼承鏈無法直接呼叫，故於測試端獨立重算。
+	 *
+	 * @param array $params 交易參數（含或不含 CheckMacValue 皆可，內部會自動排除）。
+	 * @return string 64 字元大寫 SHA256 CheckMacValue。
+	 */
+	private function generate_ecpay_check_mac_value( array $params ): string {
+		unset( $params['CheckMacValue'] );
+
+		ksort( $params, SORT_STRING | SORT_FLAG_CASE );
+
+		$pairs   = [ 'HashKey=' . self::TEST_HASH_KEY ];
+		foreach ( $params as $key => $value ) {
+			$pairs[] = $key . '=' . $value;
+		}
+		$pairs[] = 'HashIV=' . self::TEST_HASH_IV;
+
+		$check_str = implode( '&', $pairs );
+		$check_str = $this->ecpay_urlencode( $check_str );
+		$check_str = strtolower( $check_str );
+
+		return strtoupper( hash( 'sha256', $check_str ) );
+	}
+
+	/**
+	 * 複製綠界官方（.NET 風格）URL Encode 規則
+	 *
+	 * 與 RY_ECPay::urlencode() 邏輯一致：PHP urlencode() 後，將
+	 * -_.!*() 還原為未跳脫字元。
+	 *
+	 * @param string $string 原始字串。
+	 * @return string 編碼後字串。
+	 */
+	private function ecpay_urlencode( string $string ): string {
+		return str_replace(
+			[ '%2D', '%2d', '%5F', '%5f', '%2E', '%2e', '%2A', '%2a', '%21', '%28', '%29' ],
+			[ '-', '-', '_', '_', '.', '.', '*', '*', '!', '(', ')' ],
+			urlencode( $string )
+		);
+	}
+
+	/**
+	 * 組出模擬綠界 API 回應（WP_Http 回應陣列格式，body 為 URL-encoded 字串）
+	 *
+	 * QueryTradeInfo 回應含 CheckMacValue（商家須驗章）；CreditDetail/DoAction 回應
+	 * 依綠界官方規格（2885.md）「不含」CheckMacValue，故以 $include_check_mac=false
+	 * 產生符合真實契約的回應，避免測試以不存在的欄位掩蓋正式站行為。
+	 *
+	 * @param array $params            回應欄位（不含 CheckMacValue）。
+	 * @param bool  $include_check_mac 是否補上 CheckMacValue（QueryTradeInfo 為 true；DoAction 為 false）。
+	 * @return array WP_Http 風格回應陣列，可直接作為 pre_http_request 短路回傳值。
+	 */
+	private function build_ecpay_http_response( array $params, bool $include_check_mac = true ): array {
+		if ( $include_check_mac ) {
+			$params['CheckMacValue'] = $this->generate_ecpay_check_mac_value( $params );
+		}
+
+		return [
+			'headers'  => [],
+			'body'     => http_build_query( $params, '', '&' ),
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+			'cookies'  => [],
+			'filename' => null,
+		];
+	}
+
+	/**
+	 * 將一筆 QueryTradeInfo 假回應加入佇列
+	 *
+	 * @param array $overrides 覆蓋預設欄位的值。
+	 */
+	private function queue_query_response( array $overrides = [] ): void {
+		$defaults = [
+			'MerchantID'      => self::TEST_MERCHANT_ID,
+			'MerchantTradeNo' => 'TESTMTN000000',
+			'TradeNo'         => 'ECTESTTN00001',
+			'TradeAmt'        => '1000',
+			'PaymentType'     => 'Credit_CreditCard',
+			'TradeDate'       => gmdate( 'Y/m/d H:i:s' ),
+			'PaymentDate'     => gmdate( 'Y/m/d H:i:s' ),
+			'TradeStatus'     => '1',
+		];
+
+		$this->query_responses[] = $this->build_ecpay_http_response( array_merge( $defaults, $overrides ) );
+	}
+
+	/**
+	 * 將一筆 DoAction 假回應加入佇列
+	 *
+	 * @param array $overrides 覆蓋預設欄位的值。
+	 */
+	private function queue_doaction_response( array $overrides = [] ): void {
+		$defaults = [
+			'MerchantID'      => self::TEST_MERCHANT_ID,
+			'MerchantTradeNo' => 'TESTMTN000000',
+			'TradeNo'         => 'ECTESTTN00001',
+			'RtnCode'         => '1',
+			'RtnMsg'          => 'Succeeded',
+		];
+
+		// DoAction 回應不含 CheckMacValue，故 $include_check_mac=false（對齊真實契約）。
+		$this->doaction_responses[] = $this->build_ecpay_http_response( array_merge( $defaults, $overrides ), false );
+	}
+
+	/**
+	 * 從已攔截的請求中，篩選出送往 CreditDetail/DoAction 的請求
+	 *
+	 * @return array 依送出順序排列，每筆為 ['url' => string, 'body' => array]。
+	 */
+	private function get_sent_doaction_requests(): array {
+		return array_values(
+			array_filter(
+				$this->sent_requests,
+				static function ( $request ) {
+					return false !== strpos( $request['url'], 'DoAction' );
+				}
+			)
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// 案例 1：信用卡全額退款
+	// ------------------------------------------------------------------
+
+	/**
+	 * @testdox 案例1：信用卡全額退款於 DoAction 回傳 RtnCode=1 時應回傳 true
+	 * @group happy
+	 */
+	public function test_case_01_full_refund_on_credit_gateway_returns_true() {
+		$gateway = new RY_ECPay_Gateway_Credit();
+		$order   = $this->create_ecpay_order( $gateway->id, 1000, 'EC' . wp_rand( 100000, 999999 ) );
+
+		$this->queue_query_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'TradeAmt'        => '1000',
+			]
+		);
+		$this->queue_doaction_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'RtnCode'         => '1',
+				'RtnMsg'          => 'Succeeded',
+			]
+		);
+
+		$result = $gateway->process_refund( $order->get_id(), 1000, '顧客申請全額退款' );
+
+		$this->assertTrue( $result, '信用卡全額退款於 DoAction 回傳 RtnCode=1 時應回傳 true' );
+
+		$doaction_requests = $this->get_sent_doaction_requests();
+		$this->assertNotEmpty( $doaction_requests, 'process_refund 應呼叫綠界 CreditDetail/DoAction API' );
+		$this->assertSame(
+			1000,
+			(int) end( $doaction_requests )['body']['TotalAmount'],
+			'DoAction 送出的 TotalAmount 應等於全額退款金額'
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// 案例 2：信用卡部分退款
+	// ------------------------------------------------------------------
+
+	/**
+	 * @testdox 案例2：信用卡部分退款應於 DoAction 送出等於退款金額的 TotalAmount
+	 * @group happy
+	 */
+	public function test_case_02_partial_refund_sends_matching_total_amount() {
+		$gateway        = new RY_ECPay_Gateway_Credit();
+		$order          = $this->create_ecpay_order( $gateway->id, 1000, 'EC' . wp_rand( 100000, 999999 ) );
+		$partial_amount = 300;
+
+		$this->queue_query_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'TradeAmt'        => '1000',
+			]
+		);
+		$this->queue_doaction_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'RtnCode'         => '1',
+				'RtnMsg'          => 'Succeeded',
+			]
+		);
+
+		$result = $gateway->process_refund( $order->get_id(), $partial_amount, '顧客申請部分退款' );
+
+		$this->assertTrue( $result, '信用卡部分退款於 DoAction 回傳 RtnCode=1 時應回傳 true' );
+
+		$doaction_requests = $this->get_sent_doaction_requests();
+		$this->assertNotEmpty( $doaction_requests, 'process_refund 應呼叫綠界 CreditDetail/DoAction API' );
+		$this->assertSame(
+			$partial_amount,
+			(int) end( $doaction_requests )['body']['TotalAmount'],
+			'DoAction 送出的 TotalAmount 應等於部分退款金額，而非訂單全額'
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// 案例 3：未關帳降級為 Action=N
+	// ------------------------------------------------------------------
+
+	/**
+	 * @testdox 案例3：DoAction 回傳未關帳錯誤且為全額退款時應降級送出 Action=N
+	 * @group edge
+	 */
+	public function test_case_03_not_settled_downgrades_to_action_n() {
+		$gateway = new RY_ECPay_Gateway_Credit();
+		$order   = $this->create_ecpay_order( $gateway->id, 1000, 'EC' . wp_rand( 100000, 999999 ) );
+
+		$this->queue_query_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'TradeAmt'        => '1000',
+			]
+		);
+		// 第一次 DoAction（Action=R）：綠界回覆尚未關帳，無法退款。
+		$this->queue_doaction_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'RtnCode'         => '10100248',
+				'RtnMsg'          => '此筆交易尚未關帳，無法執行退款',
+			]
+		);
+		// 第二次 DoAction（降級 Action=N）：取消授權成功。
+		$this->queue_doaction_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'RtnCode'         => '1',
+				'RtnMsg'          => 'Succeeded',
+			]
+		);
+
+		$result = $gateway->process_refund( $order->get_id(), 1000, '顧客申請全額退款' );
+
+		$this->assertTrue( $result, '未關帳降級為 Action=N 且執行成功時應回傳 true' );
+
+		$doaction_requests = $this->get_sent_doaction_requests();
+		$this->assertCount(
+			2,
+			$doaction_requests,
+			'未關帳降級情境應送出兩次 DoAction 請求（先 R 後降級 N）'
+		);
+		$this->assertSame( 'R', $doaction_requests[0]['body']['Action'], '第一次 DoAction 應送出 Action=R' );
+		$this->assertSame( 'N', $doaction_requests[1]['body']['Action'], '第二次降級應送出 Action=N' );
+	}
+
+	// ------------------------------------------------------------------
+	// 案例 4：非信用卡 gateway
+	// ------------------------------------------------------------------
+
+	/**
+	 * @dataProvider provide_non_credit_gateways
+	 * @testdox 案例4：非信用卡閘道退款應回傳 WP_Error 並指引登入綠界後台（涵蓋 ATM／CVS／BARCODE／WebATM）
+	 * @group error
+	 */
+	public function test_case_04_non_credit_gateway_returns_wp_error_with_taiwanese_guidance( string $gateway_class, string $payment_type_label ) {
+		$gateway = new $gateway_class();
+		$order   = $this->create_ecpay_order( $gateway->id, 500, 'EC' . wp_rand( 100000, 999999 ) );
+
+		$result = $gateway->process_refund( $order->get_id(), 500, '顧客申請退款' );
+
+		$this->assertInstanceOf(
+			WP_Error::class,
+			$result,
+			"非信用卡閘道（{$payment_type_label}）退款應回傳 WP_Error"
+		);
+		$this->assertStringContainsString(
+			'請登入綠界廠商後台',
+			$result->get_error_message(),
+			'WP_Error 訊息應指引商家登入綠界廠商後台手動辦理退款'
+		);
+		$this->assertCount( 0, $this->sent_requests, '非信用卡閘道不應呼叫任何綠界 API' );
+	}
+
+	/**
+	 * 提供案例 4 的非信用卡閘道資料（ATM／CVS／BARCODE／WebATM）
+	 *
+	 * @return array
+	 */
+	public static function provide_non_credit_gateways(): array {
+		return [
+			'ATM 銀行轉帳'    => [ 'RY_ECPay_Gateway_Atm', 'ATM' ],
+			'CVS 超商代碼'    => [ 'RY_ECPay_Gateway_Cvc', 'CVS' ],
+			'BARCODE 超商條碼' => [ 'RY_ECPay_Gateway_Barcode', 'BARCODE' ],
+			'WebATM 網路 ATM' => [ 'RY_ECPay_Gateway_Webatm', 'WebATM' ],
+		];
+	}
+
+	// ------------------------------------------------------------------
+	// 案例 5：信用卡分期非全額退款
+	// ------------------------------------------------------------------
+
+	/**
+	 * @testdox 案例5：信用卡分期閘道非全額退款應回傳 WP_Error 且未呼叫綠界 API
+	 * @group error
+	 */
+	public function test_case_05_installment_partial_refund_rejected_without_api_call() {
+		$gateway = new WMP_ECPay_Gateway_Credit_Installment_3();
+		$order   = $this->create_ecpay_order( $gateway->id, 3000, 'EC' . wp_rand( 100000, 999999 ) );
+
+		$result = $gateway->process_refund( $order->get_id(), 1500, '顧客僅要求部分退款' );
+
+		$this->assertInstanceOf(
+			WP_Error::class,
+			$result,
+			'信用卡分期訂單要求非全額退款時應回傳 WP_Error'
+		);
+		$this->assertCount(
+			0,
+			$this->sent_requests,
+			'分期訂單非全額退款應在呼叫綠界 API 前即被拒絕'
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// 案例 6：QueryTradeInfo 網路失敗
+	// ------------------------------------------------------------------
+
+	/**
+	 * @testdox 案例6：QueryTradeInfo 網路連線失敗時應中止並回傳 WP_Error，不送出 DoAction
+	 * @group error
+	 */
+	public function test_case_06_query_trade_info_network_failure_aborts_before_do_action() {
+		$gateway = new RY_ECPay_Gateway_Credit();
+		$order   = $this->create_ecpay_order( $gateway->id, 1000, 'EC' . wp_rand( 100000, 999999 ) );
+
+		$this->query_responses[] = new WP_Error(
+			'http_request_failed',
+			'模擬連線逾時，無法連線至綠界 QueryTradeInfo'
+		);
+
+		$result = $gateway->process_refund( $order->get_id(), 1000, '顧客申請全額退款' );
+
+		$this->assertInstanceOf(
+			WP_Error::class,
+			$result,
+			'QueryTradeInfo 連線失敗時應回傳 WP_Error 並中止流程'
+		);
+		$this->assertCount( 1, $this->sent_requests, '應嘗試呼叫 QueryTradeInfo 一次' );
+		$this->assertStringContainsString(
+			'QueryTradeInfo',
+			$this->sent_requests[0]['url'],
+			'唯一送出的請求應為 QueryTradeInfo'
+		);
+		$this->assertCount(
+			0,
+			$this->get_sent_doaction_requests(),
+			'QueryTradeInfo 失敗後不應送出 DoAction 請求'
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// 案例 7：QueryTradeInfo TradeStatus 不符
+	// ------------------------------------------------------------------
+
+	/**
+	 * @testdox 案例7：QueryTradeInfo 回傳 TradeStatus 非 1 時應回傳 WP_Error
+	 * @group error
+	 */
+	public function test_case_07_query_trade_info_trade_status_mismatch_returns_wp_error() {
+		$gateway = new RY_ECPay_Gateway_Credit();
+		$order   = $this->create_ecpay_order( $gateway->id, 1000, 'EC' . wp_rand( 100000, 999999 ) );
+
+		$this->queue_query_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'TradeAmt'        => '1000',
+				'TradeStatus'     => '0',
+			]
+		);
+
+		$result = $gateway->process_refund( $order->get_id(), 1000, '顧客申請全額退款' );
+
+		$this->assertInstanceOf(
+			WP_Error::class,
+			$result,
+			'TradeStatus 非 1（尚未付款）時應回傳 WP_Error'
+		);
+		$this->assertCount( 1, $this->sent_requests, '應只呼叫 QueryTradeInfo 一次' );
+		$this->assertStringContainsString(
+			'QueryTradeInfo',
+			$this->sent_requests[0]['url'],
+			'唯一送出的請求應為 QueryTradeInfo'
+		);
+		$this->assertCount(
+			0,
+			$this->get_sent_doaction_requests(),
+			'TradeStatus 驗證失敗後不應送出 DoAction 請求'
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// 案例 8：DoAction 失敗（非未關帳）
+	// ------------------------------------------------------------------
+
+	/**
+	 * @testdox 案例8：DoAction 回傳非未關帳的失敗 RtnCode 時應回傳含 RtnMsg 的 WP_Error
+	 * @group error
+	 */
+	public function test_case_08_do_action_non_settlement_failure_returns_wp_error_with_rtn_msg() {
+		$gateway = new RY_ECPay_Gateway_Credit();
+		$order   = $this->create_ecpay_order( $gateway->id, 1000, 'EC' . wp_rand( 100000, 999999 ) );
+		$rtn_msg = '信用卡授權已取消，無法執行退款';
+
+		$this->queue_query_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'TradeAmt'        => '1000',
+			]
+		);
+		$this->queue_doaction_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'RtnCode'         => '10100050',
+				'RtnMsg'          => $rtn_msg,
+			]
+		);
+
+		$result = $gateway->process_refund( $order->get_id(), 1000, '顧客申請全額退款' );
+
+		$this->assertInstanceOf(
+			WP_Error::class,
+			$result,
+			'DoAction 回傳非未關帳的失敗代碼時應回傳 WP_Error'
+		);
+		$this->assertStringContainsString(
+			$rtn_msg,
+			$result->get_error_message(),
+			'WP_Error 訊息應包含綠界回傳的 RtnMsg 內容'
+		);
+		$this->assertCount(
+			1,
+			$this->get_sent_doaction_requests(),
+			'非未關帳的失敗不應觸發 Action=N 降級重試'
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// 案例 9：CheckMacValue 組裝正確性
+	// ------------------------------------------------------------------
+
+	/**
+	 * @testdox 案例9：DoAction 送出的 CheckMacValue 應與依官方演算法獨立重算的結果一致
+	 * @group security
+	 */
+	public function test_case_09_do_action_check_mac_value_matches_independent_recalculation() {
+		$gateway = new RY_ECPay_Gateway_Credit();
+		$order   = $this->create_ecpay_order( $gateway->id, 1000, 'EC' . wp_rand( 100000, 999999 ) );
+
+		$this->queue_query_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'TradeAmt'        => '1000',
+			]
+		);
+		$this->queue_doaction_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'RtnCode'         => '1',
+				'RtnMsg'          => 'Succeeded',
+			]
+		);
+
+		$gateway->process_refund( $order->get_id(), 1000, '顧客申請全額退款' );
+
+		$doaction_requests = $this->get_sent_doaction_requests();
+		$this->assertNotEmpty(
+			$doaction_requests,
+			'process_refund 應呼叫綠界 CreditDetail/DoAction API 才能驗證 CheckMacValue'
+		);
+
+		$sent_body = end( $doaction_requests )['body'];
+		$this->assertArrayHasKey( 'CheckMacValue', $sent_body, 'DoAction 請求應包含 CheckMacValue 欄位' );
+
+		$expected_mac = $this->generate_ecpay_check_mac_value( $sent_body );
+
+		$this->assertSame(
+			$expected_mac,
+			$sent_body['CheckMacValue'],
+			'DoAction 送出的 CheckMacValue 應與依官方演算法獨立重算的結果一致'
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// 案例 10：查無交易編號
+	// ------------------------------------------------------------------
+
+	/**
+	 * @testdox 案例10：訂單查無綠界交易編號（transaction_id 為空）時應回傳 WP_Error
+	 * @group edge
+	 */
+	public function test_case_10_missing_transaction_id_returns_wp_error() {
+		$gateway = new RY_ECPay_Gateway_Credit();
+		$order   = $this->create_ecpay_order( $gateway->id, 1000, null );
+
+		$this->assertSame( '', $order->get_transaction_id(), '前置條件：訂單應無綠界交易編號' );
+
+		$result = $gateway->process_refund( $order->get_id(), 1000, '顧客申請全額退款' );
+
+		$this->assertInstanceOf(
+			WP_Error::class,
+			$result,
+			'訂單缺少綠界交易編號（TradeNo）時應回傳 WP_Error，而非嘗試呼叫 API'
+		);
+		$this->assertNotEmpty(
+			$result->get_error_message(),
+			'WP_Error 應攜帶說明訊息'
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// 案例 11：DoAction 回應綁定防偽（回應 TradeNo 與訂單不符）
+	// ------------------------------------------------------------------
+
+	/**
+	 * @testdox 案例11：DoAction 回應的 TradeNo 與訂單不符時應回傳 WP_Error（回應綁定防偽）
+	 * @group security
+	 */
+	public function test_case_11_do_action_response_trade_no_mismatch_returns_wp_error() {
+		$gateway = new RY_ECPay_Gateway_Credit();
+		$order   = $this->create_ecpay_order( $gateway->id, 1000, 'EC' . wp_rand( 100000, 999999 ) );
+
+		$this->queue_query_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'TradeAmt'        => '1000',
+			]
+		);
+		// 綠界 DoAction 回應不含 CheckMacValue，防偽改綁定 TradeNo；此處模擬回應的 TradeNo 被竄改為他筆交易。
+		$this->queue_doaction_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => 'EVILTRADENO999',
+				'RtnCode'         => '1',
+				'RtnMsg'          => 'Succeeded',
+			]
+		);
+
+		$result = $gateway->process_refund( $order->get_id(), 1000, '顧客申請全額退款' );
+
+		$this->assertInstanceOf(
+			WP_Error::class,
+			$result,
+			'DoAction 回應的 TradeNo 與本訂單不符時應回傳 WP_Error，不可誤判為退款成功'
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// 案例 12：DoAction 回應綁定防偽（回應 MerchantTradeNo 與訂單不符）
+	// ------------------------------------------------------------------
+
+	/**
+	 * @testdox 案例12：DoAction 回應的 MerchantTradeNo 與訂單不符時應回傳 WP_Error（回應綁定防偽）
+	 * @group security
+	 */
+	public function test_case_12_do_action_response_merchant_trade_no_mismatch_returns_wp_error() {
+		$gateway = new RY_ECPay_Gateway_Credit();
+		$order   = $this->create_ecpay_order( $gateway->id, 1000, 'EC' . wp_rand( 100000, 999999 ) );
+
+		$this->queue_query_response(
+			[
+				'MerchantTradeNo' => $order->get_meta( '_ecpay_MerchantTradeNo' ),
+				'TradeNo'         => $order->get_transaction_id(),
+				'TradeAmt'        => '1000',
+			]
+		);
+		// 回應的 MerchantTradeNo 被竄改為他筆訂單，綁定驗證應攔截。
+		$this->queue_doaction_response(
+			[
+				'MerchantTradeNo' => 'EVILMTN000000',
+				'TradeNo'         => $order->get_transaction_id(),
+				'RtnCode'         => '1',
+				'RtnMsg'          => 'Succeeded',
+			]
+		);
+
+		$result = $gateway->process_refund( $order->get_id(), 1000, '顧客申請全額退款' );
+
+		$this->assertInstanceOf(
+			WP_Error::class,
+			$result,
+			'DoAction 回應的 MerchantTradeNo 與本訂單不符時應回傳 WP_Error'
+		);
+	}
+}

--- a/woomp.php
+++ b/woomp.php
@@ -4,7 +4,7 @@
  * Plugin Name:       好用版擴充 MorePower Addon for WooCommerce
  * Plugin URI:        https://morepower.club/morepower-addon/
  * Description:       WooCommerce 好用版擴充，改善結帳流程與可變商品等區塊，並整合多項金流，讓 WooCommerce 更符合亞洲人使用習慣。
- * Version:           3.5.12
+ * Version:           3.5.13
  * Author:            MorePower
  * Author URI:        https://morepower.club
  * License:           GPL-2.0+


### PR DESCRIPTION
## 概述

解決 issue #123：WooCommerce 後台對綠界信用卡訂單按「退款」時，自動呼叫綠界 `CreditDetail/DoAction` 同步退刷，取代原本「後台改狀態 → 店家再登綠界後台手動退」的斷裂流程。非信用卡（ATM/超商/條碼/WebATM）綠界無線上退款 API，回傳繁中人工退款指引。

Closes #123

## 實作（方案 B′）

- `RY_ECPay_Gateway_Base` 宣告 `supports[]='refunds'`，`process_refund` 依 `payment_type` 分流。
- `process_credit_refund` 編排：`QueryTradeInfo` 前置驗證 → `Action=R` 退刷 → 綠界回「未關帳」且全額時降級 `Action=N`。
- **回應驗證分路**（security review 修正的關鍵）：`QueryTradeInfo` 回應以 `hash_equals` 驗 CheckMacValue；`CreditDetail/DoAction` 回應依官方規格（2885.md）**不含 CheckMacValue**，改綁定「回應 `MerchantTradeNo/TradeNo` === 本訂單」+ TLS 防偽。
- fail-closed：任何查詢/API 失敗、驗證不符、`TradeStatus≠1` 一律回 `WP_Error` 不標記已退款；成功唯一判準 `RtnCode=='1'`。金額雙邊一致取整 + 超額防護；分期強制全額退款。

## 測試

- 退款整合測試 `EcpayRefundTest.php`：**15 tests / 43 assertions 全綠**（全程 mock 綠界 API）。
- 整合迴歸：`OK (211 tests)` 未破壞既有。
- phpcs：零新增違規。
- 經 **2 輪 security review**，判定可合併（High-1 DoAction 回應驗章契約缺陷、Medium-1 金額取整已修復並複審確認）。

## ⚠️ 合併前須知

- **正式站人工驗收（必做）**：綠界 DoAction 測試環境不支援真實授權，自動測試全為 mock。上線前請以小額真單（NT$1~5）跑一次全額 + 一次部分退款，確認綠界後台實際退刷。退款不可逆。
- **待列管（Medium-2，既有技術債）**：既有付款 callback `ecpay-gateway-response.php:36` 的 CheckMacValue 驗章用 `==`（非 timing-safe），非本次退款引入，建議另案改用 `hash_equals`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015acuVrvDNRNd7UVE7u2f2w
